### PR TITLE
Simplify installation and build invocation; add CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    with:
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: nextstrain/base:branch-nextalign-v2

--- a/README.md
+++ b/README.md
@@ -13,14 +13,10 @@ Add any additional sequences and metadata in separate fasta or metadata-tsv file
 
 Run pipeline with:
 ```
-snakemake -j 1 -p --configfile=config/config.yaml
+nextstrain build --image=nextstrain/base:branch-nextalign-v2 . --configfile=config/config.yaml
 ```
 
 View results with:
-```
-auspice view --datasetDir auspice/
-```
-or with:
 ```
 nextstrain view auspice/
 ```
@@ -92,57 +88,5 @@ uncertain.
 
 ## Installation
 
-This pipeline uses:
- - [augur](https://github.com/nextstrain/augur) >v15.0
- - [nextalign](https://github.com/nextstrain/nextclade) >v2.0.1
- - [TreeTime](https://github.com/neherlab/treetime) >v0.9.0
- - [IQTREE](https://github.com/Cibiv/IQ-TREE) >v2.1.2
-
-Augur, TreeTime and IQTREE can be installed as is standard. Nextalign requires installation of latest (not yet released) version.
-
-Clone repo
-```
-git clone https://github.com/nextstrain/nextclade
-cd nextclade
-```
-
-Install `rustup`
-```
-# Check if rustup (Rust toolchain manager) is installed
-which rustup
-
-# If not installed, install (https://rustup.rs/)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# Add toolchain bin directory to $PATH
-export PATH="$PATH:$HOME/.cargo/bin"
-```
-
-Set environment variables
-```
-echo "DATA_FULL_DOMAIN=https://data.master.clades.nextstrain.org" > .env
-```
-
-Building
-```
-# Build Nextalign in release mode (fast to run, slow to build, no debug info)
-cargo build --release --bin nextalign
-```
-
-Test installation
-```
-./target/release/nextalign run \
-  --in-order \
-  --include-reference \
-  --sequences=data/sars-cov-2/sequences.fasta \
-  --reference=data/sars-cov-2/reference.fasta \
-  --genemap=data/sars-cov-2/genemap.gff \
-  --genes=E,M,N,ORF1a,ORF1b,ORF3a,ORF6,ORF7a,ORF7b,ORF8,ORF9b,S \
-  --output-dir=tmp/ \
-  --output-basename=nextalign
-```
-
-Copy `nextalign` binary to somewhere globally accessible
-```
-sudo cp target/release/nextalign /usr/local/bin/
-```
+Follow the [standard installation instructions](https://docs.nextstrain.org/en/latest/install.html) for Nextstrain's suite of software tools.
+Please choose the installation method for your operating system which uses Docker, as currently a pre-release version of Nextalign is required which we've baked into the `--image` argument to `nextstrain build` above.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add any additional sequences and metadata in separate fasta or metadata-tsv file
 
 Run pipeline with:
 ```
-nextstrain build --image=nextstrain/base:branch-nextalign-v2 . --configfile=config/config.yaml
+nextstrain build --image=nextstrain/base:branch-nextalign-v2 .
 ```
 
 View results with:
@@ -23,7 +23,7 @@ nextstrain view auspice/
 
 ## Configuration
 
-Configuration takes place the `config/config.yml`.
+Configuration takes place in `config/config.yml` by default.
 The analysis pipeline is contained in `workflow/snakemake_rule/core.smk`.
 This can be read top-to-bottom, each rule specifies its file inputs and output and pulls its parameters from `config`.
 There is little redirection and each rule should be able to be reasoned with on its own.

--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,6 @@
+if not config:
+    configfile: "config/config.yaml"
+
 build_dir = "results"
 auspice_dir = "auspice"
 


### PR DESCRIPTION
Uses an alternate runtime image with Nextalign v2 already baked in.

Also simplified the invocation so the default config file is used by default.

Also added CI to help ensure the build works in the face of changes (from pushes and PRs).

### Related issue(s)
Related to https://github.com/nextstrain/docker-base/pull/43 and https://github.com/nextstrain/.github/pull/23.

### Testing
- [x] `nextstrain build` command shown works for me.
- [x] CI [works](https://github.com/nextstrain/monkeypox/runs/6563968947?check_suite_focus=true) ([output artifacts](https://github.com/nextstrain/monkeypox/suites/6628066966/artifacts/249833482))