### PR TITLE
README: Add --docker and --cpus 1 to the example `nextstrain build` invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add any additional sequences and metadata in separate fasta or metadata-tsv file
 
 Run pipeline with:
 ```
-nextstrain build --image=nextstrain/base:branch-nextalign-v2 .
+nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 --cpus 1 .
 ```
 
 View results with:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Run pipeline with:
 nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 --cpus 1 .
 ```
 
+Adjust the number of CPUs to what your machine has available you want to perform alignment and tree building a bit faster.
+
 View results with:
 ```
 nextstrain view auspice/

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -59,11 +59,12 @@ rule align:
     params:
         max_indel = config["max_indel"],
         seed_spacing = config["seed_spacing"]
+    threads: workflow.cores
     shell:
         """
         nextalign run \
             -v \
-            --jobs 1 \
+            --jobs {threads} \
             --sequences {input.sequences} \
             --reference {input.reference} \
             --max-indel {params.max_indel} \
@@ -97,11 +98,13 @@ rule tree:
         alignment = build_dir + "/{build_name}/masked.fasta"
     output:
         tree = build_dir + "/{build_name}/tree_raw.nwk"
+    threads: 8
     shell:
         """
         augur tree \
             --alignment {input.alignment} \
-            --output {output.tree}
+            --output {output.tree} \
+            --nthreads {threads}
         """
 
 rule refine:
@@ -127,6 +130,7 @@ rule refine:
         root = config["root"],
         clock_rate = config["clock_rate"],
         clock_std_dev = config["clock_std_dev"]
+    threads: 1
     shell:
         """
         augur refine \


### PR DESCRIPTION
The --image argument is ignored unless a containerized runtime is used
(Docker or AWS Batch currently).  Under the "native"/ambient runtime,
which may be the default for some installations, a warning will be
emitted but ultimately --image will be ignored.  Specifying --docker
explicitly means a more obvious (although still not good) error occurs
earlier.  These two arguments are temporary until Nextalign v2 has a
stable release.

Relatedly, specifying --cpus 1 now heads off issues with
"native"/ambient environments with newer Snakemake's until Nextstrain
CLI accounts for that automatically.  While this invocation doesn't use
the "native"/ambient runtime now, including --cpus now means that when
--image and --docker are no longer necessary we can simply remove them.
Before that point, it also provides a guidance point for people using
variants of this example invocation.

Ultimately, given further work within our ecosystem (Nextalign,
Nextstrain CLI), this whole invocation should revert back to just
`nextstrain build .`.

### Related issue(s)
Related to #8 

### Testing
Ran new example invocation under environments where the
- [x] Docker runtime is default
- [x] Native ("ambient') runtime is default, but Docker runtime is supported
- [x] Docker runtime is not supported