### PR TITLE
Add LAPIS entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,23 @@ has been saved to `example_data/outbreak.fasta`.
 
 ### Data preparation
 
-Move metadata to `data/`:
+**Option 1:**
+
+Collect data as described above and store in one or more `data/*.fasta` and `data/*.tsv` file(s).
+
+**Option 2:**
+
+Move the provided metadata and sequences to `data/`:
 ```
 cp example_data/metadata.tsv data/metadata.tsv
+cat example_data/sequences.fasta example_data/outbreak.fasta > data/sequences.fasta
 ```
 
-Move and append sequences to `data/`
+**Option 3:**
+
+Download data using [LAPIS](https://mpox-lapis.gen-spectrum.org/docs)
 ```
-cat example_data/sequences.fasta example_data/outbreak.fasta > data/sequences.fasta
+snakemake --cores 1 -f download_via_lapis
 ```
 
 ### Data use

--- a/workflow/snakemake_rules/prepare.smk
+++ b/workflow/snakemake_rules/prepare.smk
@@ -8,3 +8,15 @@ rule prepare:
         cat data/*fasta > {output.sequences}
         cat data/*tsv > {output.metadata}
         """
+
+rule download_via_lapis:
+    output:
+        sequences = "data/sequences_lapis.fasta",
+        metadata = "data/metadata_lapis.tsv"
+    shell:
+        """
+        curl https://mpox-lapis.gen-spectrum.org/v1/sample/fasta --output {output.sequences}
+        curl https://mpox-lapis.gen-spectrum.org/v1/sample/details?dataFormat=csv | \
+            tr -d "\r" |
+            sed -E 's/("([^"]*)")?,/\\2\\t/g' > {output.metadata}
+        """


### PR DESCRIPTION
While this is slightly circular, it's useful for quick testing and may
become a more standard entrypoint as the ingest becomes automated. The
LAPIS metadata is missing some fields compared to the example metadata
(e.g. "outbreak_associated") but contains some fields the example
metadata does not.
