### PR TITLE
lat_long.tsv

### DIFF
--- a/config/exclude.txt
+++ b/config/exclude.txt
@@ -1,3 +1,6 @@
+# for now, too many sequencing errors
+MPXV-CH-38134631/2022
+
 # exclude viruses from Congo Basin clade
 015c_contig_SPADES
 18_contig_SPADES

--- a/config/lat_longs.tsv
+++ b/config/lat_longs.tsv
@@ -1,4 +1,24 @@
-country	democratic_republic_of_the_congo	-3.394559	23.306004
-country	democratic republic of the congo	-3.394559	23.306004
-country	central_african_republic	4.366667	18.583333
-country	cote_dIvoire	6.85	-5.3
+country	Belgium	50.707735	4.677726
+country	Cameroon	4.6125522	13.1535811
+country	Cote d'Ivoire	7.9897371	-5.5679458
+country	Democratic Republic of the Congo	-4.0383	21.7587
+country	France	46.2276	2.2137
+country	Gabon	-0.8999695	11.6899699
+country	Germany	51.1657	10.4515
+country	Israel	31.217736	34.903129
+country	Netherlands	52.1326	5.2913
+country	Nigeria	10.0	8.0
+country	Portugal	39.54046	-8.174701
+country	Sierra Leone	8.6400349	-11.8400269
+country	Singapore	1.344189	103.867546
+country	Switzerland	46.8182	8.2275
+country	United Kingdom	51.82930075394037	-2.129498250860435
+country	USA	38.916963	-98.891372
+region	Africa	4.070194	21.824559
+region	Asia	30.451098	86.654576
+region	Europe	49.646237	10.799454
+region	North America	28.2367447	-97.738017
+country	Liberia	6.334995000938028	-9.323955308206793
+country	Sudan	16.490528766519194	30.66033360090796
+country	Central African Republic	6.207918975163378	20.72869278708794
+region	West Asia	34.604403366209084	43.32277708212641

--- a/example_data/metadata.tsv
+++ b/example_data/metadata.tsv
@@ -104,3 +104,4 @@ Monkeypox/PT0005/2022	XXXXXXXX	2022-05-15	Europe	Portugal	human	yes	WA
 Monkeypox/PT0008/2022	XXXXXXXX	2022-05-15	Europe	Portugal	human	yes	WA
 MPXV-BY-IMB25241	ON568298	2022-05-19	Europe	Germany	human	yes	WA
 Monkeypox_virus_MPX/Human/mpx_UZ-REGA-1/Belgium/2022_version_8	XXXXXXXX	2022-05-19	Europe	Belgium	human	yes	WA
+MPXV-CH-38134631/2022	ON595760	2022-05-19	Europe	Switzerland	human	yes	WA


### PR DESCRIPTION
I made a new version of lat_long.tsv because on the nextstrain tree Cote d'Ivoire isn't shown on the map,
but I think you are using a different file so mine might be useless.

This pull request also adds the new Switzerland sequence in metadata.tsv, also added to the excludes (and not to outbreak.fasta) because it has a 8 sequencing errors