### PR TITLE
fix: change LAPIS URL - gen-spectrum.org -> genspectrum.org

### DIFF
--- a/workflow/snakemake_rules/download_via_lapis.smk
+++ b/workflow/snakemake_rules/download_via_lapis.smk
@@ -1,11 +1,17 @@
-rule download_via_lapis:
+rule download_sequences_via_lapis:
     output:
         sequences = "data/sequences.fasta",
+    shell:
+        """
+        curl https://mpox-lapis.genspectrum.org/v1/sample/fasta --output {output.sequences}
+        """
+
+rule download_metadata_via_lapis:
+    output:
         metadata = "data/metadata.tsv"
     shell:
         """
-        curl https://mpox-lapis.gen-spectrum.org/v1/sample/fasta --output {output.sequences}
-        curl https://mpox-lapis.gen-spectrum.org/v1/sample/details?dataFormat=csv | \
+        curl https://mpox-lapis.genspectrum.org/v1/sample/details?dataFormat=csv | \
             tr -d "\r" |
             sed -E 's/("([^"]*)")?,/\\2\\t/g' > {output.metadata}
         """


### PR DESCRIPTION
### Description of proposed changes
LAPIS has changed top-level domain URL from gen-spectrum.org to genspectrum.org

I also split the download rule into metadata and sequences so as to be able to download just sequences but not metadata if one wants to use own metadata.