### PR TITLE
Adding exclusions

### DIFF
--- a/config/exclude.txt
+++ b/config/exclude.txt
@@ -51,4 +51,3 @@ W_Nigeria
 
 # potentially problematic
 MPXV_1_IT_Milan_2022  # many extra mutations
-MPXV_FR_HCL0001_2022  # any reversions in terminal regions

--- a/config/exclude.txt
+++ b/config/exclude.txt
@@ -51,3 +51,4 @@ W_Nigeria
 
 # potentially problematic
 MPXV_1_IT_Milan_2022  # many extra mutations
+MPXV_GSTT_Patient1 # reversions in 3' terminal region

--- a/config/exclude_outbreak.txt
+++ b/config/exclude_outbreak.txt
@@ -86,3 +86,4 @@ MPXV_WRAIR7_61__Walter_Reed_267
 # potentially problematic
 MPXV_1_IT_Milan_2022  # many extra mutations
 MPXV_FR_HCL0001_2022  # any reversions in terminal regions
+MPXV_GSTT_Patient1 # reversions in 3' terminal region

--- a/config/exclude_outbreak.txt
+++ b/config/exclude_outbreak.txt
@@ -85,5 +85,4 @@ MPXV_WRAIR7_61__Walter_Reed_267
 
 # potentially problematic
 MPXV_1_IT_Milan_2022  # many extra mutations
-MPXV_FR_HCL0001_2022  # any reversions in terminal regions
 MPXV_GSTT_Patient1 # reversions in 3' terminal region

--- a/config/exclude_overview.txt
+++ b/config/exclude_overview.txt
@@ -5,3 +5,6 @@ UNKNOWN_FV537351
 UNKNOWN_FV537352
 UTC
 Sudan_2005_01
+MPXV_1_IT_Milan_2022  # many extra mutations
+MPXV_FR_HCL0001_2022  # any reversions in terminal regions
+MPXV_GSTT_Patient1 # reversions in 3' terminal region

--- a/config/exclude_overview.txt
+++ b/config/exclude_overview.txt
@@ -6,5 +6,4 @@ UNKNOWN_FV537352
 UTC
 Sudan_2005_01
 MPXV_1_IT_Milan_2022  # many extra mutations
-MPXV_FR_HCL0001_2022  # any reversions in terminal regions
 MPXV_GSTT_Patient1 # reversions in 3' terminal region


### PR DESCRIPTION
This adds one sequence that seems to be missing 3' mutations to both exclude_overview and exclude_outbreak:

```
MPXV_GSTT_Patient1 # reversions in 3' terminal region
```

It additionally copies ~~2~~ the sequence above and an additional one below from exclude_outbreak to exclude_overview and exclude.txt:
```
MPXV_1_IT_Milan_2022  # many extra mutations
```
