### PR TITLE
feat(ingest): output dates with `-XX` for unknown month/date

### DIFF
--- a/ingest/bin/transform-date-fields
+++ b/ingest/bin/transform-date-fields
@@ -19,10 +19,10 @@ def format_date(date_string: str, expected_formats: set) -> str:
     >>> expected_formats = {'%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ'}
 
     >>> format_date("2020", expected_formats)
-    '2020'
+    '2020-XX-XX'
 
     >>> format_date("2020-01", expected_formats)
-    '2020-01'
+    '2020-01-XX'
 
     >>> format_date("2020-1-15", expected_formats)
     '2020-01-15'
@@ -38,9 +38,13 @@ def format_date(date_string: str, expected_formats: set) -> str:
     """
     for date_format in expected_formats:
         try:
-            return datetime.strptime(date_string, date_format).strftime('%Y-%m-%d')
+            parsed_date = datetime.strptime(date_string, date_format)
         except ValueError:
             continue
+        year_string = str(parsed_date.year)
+        month_string = str(parsed_date.month).zfill(2) if date_string.count('-') >= 1 else 'XX'
+        day_string = str(parsed_date.day).zfill(2) if date_string.count('-') == 2 else 'XX'
+        return f"{year_string}-{month_string}-{day_string}"
 
     if date_string:
         print(

--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -15,7 +15,7 @@ transform:
   # List of date fields to standardize
   date_fields: ['date', 'date_submitted']
   # Expected date formats present in date fields
-  expected_date_formats: ['%Y-%m-%d', '%Y_%m_%d', '%Y-%m-%dT%H:%M:%SZ']
+  expected_date_formats: ['%Y', '%Y-%m', '%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
   # Titlecase rules
   titlecase:
     # Abbreviations not cast to titlecase, keeps uppercase


### PR DESCRIPTION
Augur filter expects unknowns in dates to be of the format `2018-XX-XX`. This PR switches dates over to that format.

The code is not the most elegant but it works for now. It's important to check the logs occasionally to see what went wrong. Maybe we should tee the logs to stdout somehow, since otherwise warnings like unparsed dates are hard to spot.