### PR TITLE
Add `institution` to MPX metadata

### DIFF
--- a/ingest/bin/merge-user-metadata
+++ b/ingest/bin/merge-user-metadata
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     with open(args.annotations, 'r') as annotations_fh:
         csv_reader = csv.reader(annotations_fh, delimiter='\t')
         for row in csv_reader:
-            if row[0].lstrip()[0] == '#':
+            if not row or row[0].lstrip()[0] == '#':
                     continue
             elif len(row) != 3:
                 print("WARNING: Could not decode annotation line " + "\t".join(row), file=stderr)

--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -58,4 +58,5 @@ transform:
     'clade',
     'abbr_authors',
     'authors',
+    'institution'
   ]

--- a/ingest/source-data/annotations.tsv
+++ b/ingest/source-data/annotations.tsv
@@ -324,3 +324,159 @@ ON649723	clade	WA
 ON649724	clade	WA
 ON649725	clade	WA
 ON649879	clade	WA
+#
+ON645312	institution	Centre for Clinical Infection & Diagnostics Research, Kings College London, St Thomas Hospital, UK
+ON631963	institution	Victorian Infectious Diseases Reference Laboratory, Doherty Institute, Australia
+ON568298	institution	Microbiol Genomics & Bioinformatics, Bundeswehr Institute of Microbiology, Germany
+ON637938	institution	Centre for Biological Threats, Highly Pathogenic Viruses, Robert Koch Institute, Germany
+ON637939	institution	Centre for Biological Threats, Highly Pathogenic Viruses, Robert Koch Institute, Germany
+AY603973	institution	Biochemistry & Microbiology, University of Victoria, Canada
+AY753185	institution	Biochemistry & Microbiology, University of Victoria, Canada
+AY741551	institution	Biochemistry & Microbiology, University of Victoria, Canada
+MN648051	institution	Biochemistry & Molecular Genetics, Israel Institute for Biological Research, Israel
+ON602722	institution	IHAP, VIRAL, Universite de Toulouse, INRAE, ENVT, France
+HQ857563	institution	Vaccine and Gene Therapy Institute, Oregon Health and Science University, USA
+HQ857562	institution	Vaccine and Gene Therapy Institute, Oregon Health and Science University, USA
+HM172544	institution	Virology, The United States Army Medical Research Institute for Infectious Diseases (USAMRIID), USA
+ON676707	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON676703	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON675438	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON676704	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON676705	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON676708	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON674051	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON676706	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON563414	institution	Division of High-Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+ON614676	institution	Laboratory of Virology, INMI Lazzaro Spallanzani IRCCS, Italy
+ON585034	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585036	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649708	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649710	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585031	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585035	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585037	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649712	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585030	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649715	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649716	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649713	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649718	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649720	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649722	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649723	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649724	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649725	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585032	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585029	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585033	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON585038	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649711	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649714	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649717	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649709	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649721	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649719	institution	Institute National de Saude Doutor Ricardo Jorge (INSA), Portugal
+ON649879	institution	Biochemistry & Molecular Genetics, Israel Institute for Biological Research, Israel
+JX878422	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878412	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878416	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878410	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878426	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878428	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878407	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878411	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878419	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878413	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878429	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878423	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878424	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878421	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878414	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878420	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878415	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878427	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878408	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878425	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878409	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878418	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+JX878417	institution	Center for Genome Sciences, United States Army Medical Research Institute of Infectious Diseases (USAMRIID), USA
+ON622721	institution	Department of Biomedical & Clinical Sciences, University of Milan, Italy
+ON595760	institution	Laboratory of Viorology, University Hospital of Geneva, Switzerland
+ON622720	institution	Laboratory of Viorology, University Hospital of Geneva, Switzerland
+ON644344	institution	Genomics & Epigenomics, AREA Science Park, Italy
+DQ011157	institution	National Center for Infectious Diseases, Centers for Disease Control and Prevention (US CDC), USA
+DQ011153	institution	National Center for Infectious Diseases, Centers for Disease Control and Prevention (US CDC), USA
+DQ011154	institution	National Center for Infectious Diseases, Centers for Disease Control and Prevention (US CDC), USA
+DQ011156	institution	National Center for Infectious Diseases, Centers for Disease Control and Prevention (US CDC), USA
+MT724769	institution	Biology, Universiteit Antwerpen, Belgium
+MT724770	institution	Biology, Universiteit Antwerpen, Belgium
+MT724772	institution	Biology, Universiteit Antwerpen, Belgium
+MT724771	institution	Biology, Universiteit Antwerpen, Belgium
+ON622718	institution	Microbiology, Hospital Universitari Germans Trias i Pujol, Spain
+MT903342	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903340	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903338	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903348	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903347	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903346	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903341	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903337	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903339	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+FV537351	institution	Genetics Signatures, Sydney, Australia
+FV537352	institution	Genetics Signatures, Sydney, Australia
+FV537349	institution	Genetics Signatures, Sydney, Australia
+FV537350	institution	Genetics Signatures, Sydney, Australia
+KC257459	institution	Biochemistry & Microbiology, University of Victoria, Canada
+KC257460	institution	Biochemistry & Microbiology, University of Victoria, Canada
+KJ642615	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642619	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642613	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642618	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642612	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642614	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642617	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KJ642616	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KP849470	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KP849471	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+KP849469	institution	Poxvirus Program, Centres for Disease Control and prevention (US CDC), USA
+ON619838	institution	Research & Evaluation, UKHSA, UK
+ON619837	institution	Research & Evaluation, UKHSA, UK
+ON619836	institution	Research & Evaluation, UKHSA, UK
+ON619835	institution	Research & Evaluation, UKHSA, UK
+ON615424	institution	Public Health Virology, Erasmus Medical Centre, The Netherlands
+MN346690	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346693	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346692	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346702	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346698	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346694	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346696	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346699	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346695	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+MN346700	institution	Project Group Epidemiology of Highly Pathogenic Microorganisms, Robert Koch Institute, Germany
+KJ136820	institution	Centre for Biological Security, Robert Koch Institute, Germany
+MN702444	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702445	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702448	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702450	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702453	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702452	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702451	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702446	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702449	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+MN702447	institution	Virology, Centre International de Recherches Medicales de Franceville, CIRMF, Gabon
+NC_003310	institution	Department of Molecular Biology of Genomes, SRC VB Vector, Russia
+ON622712	institution	Microbiology, Immunology & Transplantation, KU Leuven, Rega Institute, Belgium
+ON622713	institution	Microbiology, Immunology & Transplantation, KU Leuven, Rega Institute, Belgium
+MK783031	institution	NCEZID/DHCPP/PRB, Centers for Disease Control & Prevention (US CDC), USA
+MK783029	institution	NCEZID/DHCPP/PRB, Centers for Disease Control & Prevention (US CDC), USA
+MK783030	institution	NCEZID/DHCPP/PRB, Centers for Disease Control & Prevention (US CDC), USA
+MK783028	institution	NCEZID/DHCPP/PRB, Centers for Disease Control & Prevention (US CDC), USA
+MK783032	institution	NCEZID/DHCPP/PRB, Centers for Disease Control & Prevention (US CDC), USA
+ON627808	institution	Department of Health, Utah Public Health Laboratory, USA
+ON609725	institution	Laboratory for Diagnostics of Zoonoses & WHO Centre, Institute of Microbiology & Immunology, Faculty of Medicine, University of Ljubljana, Slovenia
+ON631241	institution	Laboratory for Diagnostics of Zoonoses & WHO Centre, Institute of Microbiology & Immunology, Faculty of Medicine, University of Ljubljana, Slovenia
+ON622722	institution	Virology, GENomique EPIdemiologique das maladies Infectieuses, France
+MT903344	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903343	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA
+MT903345	institution	National Center for Emerging and Zoonotic Infectious Diseases, Division of High Consequence Pathogens & Pathology, Centers for Disease Control & Prevention (US CDC), USA


### PR DESCRIPTION
### Description of proposed changes

Adds manually-curated institution information for most WA clade MPX seqs
- Adds data to `souce-data/annotations.tsv`
- Adds an extra field `institution` to the final metadata file (we may want to amend this field name)

Will not have info for any sequences added since Saturday.

We likely want to try to automate this in future from INSDC data, but this makes a good start at better crediting sequence submitters.

The edit to `merge-user-metadata` is because while testing I noticed that multiple empty lines at the end of `annotations.tsv` or any empty line in the middle of the file caused an error. I think it's fine to handle this more robustly and just ignore empty lines.

### Testing
Ran locally, seemed to output appropriately, but extra eyes appreciated. 

