### PR TITLE
Force line endings to be LF on check out

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Always use LF line endings even on Windows.
+* text eol=lf


### PR DESCRIPTION
### Description of proposed changes

Fixes an issue for users running workflows on Windows where git clone will convert line endings to CRLF by default, even though users will run the workflows in a UNIX-style system through Docker. This commit forces line endings to be LF regardless of the platform.

### Testing

 - [ ] Tested with Mac OS
 - [ ] Tested with Windows