### PR TITLE
Fetch from S3 rather than sequences from LAPIS and metadata from example data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,9 @@ This is the [Nextstrain](https://nextstrain.org) build for monkeypox virus. Outp
 
 ### Provision input data
 
-Retrieve input sequences using LAPIS and write to `data/` with:
+Retrieve input sequences and metadata from data.nextstrain.org and write to `data/` with:
 ```
-nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 . data/sequences.fasta
-```
-
-Copy metadata with:
-```
-cp example_data/metadata.tsv data/
+nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 . data/sequences.fasta data/metadata.tsv
 ```
 
 ### Run analysis pipeline

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,6 @@ lat_longs: "config/lat_longs.tsv"
 auspice_config: "config/auspice_config.json"
 description: "config/description.md"
 
-data_source: "lapis"
 strain_id_field: "accession"
 display_strain_field: "strain_original"
 

--- a/workflow/snakemake_rules/prepare.smk
+++ b/workflow/snakemake_rules/prepare.smk
@@ -1,11 +1,27 @@
-
-rule concatenate_data:
+rule download:
+    message: "Downloading sequences and metadata from data.nextstrain.org"
     output:
-        sequences = "data/sequences.fasta",
-        metadata =  "data/metadata.tsv"
+        sequences = "data/sequences.fasta.xz",
+        metadata = "data/metadata.tsv.gz"
+    params:
+        sequences_url = "https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz",
+        metadata_url = "https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz"
     shell:
         """
-        cat example_data/*fasta > {output.sequences}
-        cat example_data/*tsv > {output.metadata}
+        curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}
+        curl -fsSL --compressed {params.metadata_url:q} --output {output.metadata}
         """
 
+rule decompress:
+    message: "Decompressing sequences and metadata"
+    input:
+        sequences = "data/sequences.fasta.xz",
+        metadata = "data/metadata.tsv.gz"
+    output:
+        sequences = "data/sequences.fasta",
+        metadata = "data/metadata.tsv"
+    shell:
+        """
+        gzip --decompress --keep {input.metadata}
+        xz --decompress --keep {input.sequences}
+        """


### PR DESCRIPTION
- Download sequences and metadata from data.nextstrain.org
- Remove `data_source: lapis` from default config to use prepare.smk instead of download_via_lapis.smk
