### PR TITLE
CloudFront Invalidation

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -56,6 +56,25 @@ Do the following to include sequences from static FASTA files.
 Configuration takes place in `config/config.yaml` by default.
 Optional configs for uploading files and Slack notifications are in `config/optional.yaml`.
 
+### Environment Variables
+
+The complete ingest pipeline with AWS S3 uploads and Slack notifications uses the following environment variables:
+
+#### Required
+
+- `AWS_DEFAULT_REGION`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `SLACK_TOKEN`
+- `SLACK_CHANNELS`
+
+#### Optional
+
+These are optional environment variables used in our automated pipeline for providing detailed Slack notifications.
+
+- `GITHUB_RUN_ID` - provided via [`github.run_id` in a GitHub Action workflow](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
+- `AWS_BATCH_JOB_ID` - provided via [AWS Batch Job environment variables](https://docs.aws.amazon.com/batch/latest/userguide/job_env_vars.html)
+
 ## Input data
 
 ### GenBank data

--- a/ingest/bin/cloudfront-invalidate
+++ b/ingest/bin/cloudfront-invalidate
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Originally from @tsibley's gist: https://gist.github.com/tsibley/a66262d341dedbea39b02f27e2837ea8
+set -euo pipefail
+
+main() {
+    local domain="$1"
+    shift
+    local paths=("$@")
+    local distribution invalidation
+
+    echo "-> Finding CloudFront distribution"
+    distribution=$(
+        aws cloudfront list-distributions \
+            --query "DistributionList.Items[?contains(Aliases.Items, \`$domain\`)] | [0].Id" \
+            --output text
+    )
+
+    if [[ -z $distribution || $distribution == None ]]; then
+        exec >&2
+        echo "Unable to find CloudFront distribution id for $domain"
+        echo
+        echo "Are your AWS CLI credentials for the right account?"
+        exit 1
+    fi
+
+    echo "-> Creating CloudFront invalidation for distribution $distribution"
+    invalidation=$(
+        aws cloudfront create-invalidation \
+            --distribution-id "$distribution" \
+            --paths "${paths[@]}" \
+            --query Invalidation.Id \
+            --output text
+    )
+
+    echo "-> Waiting for CloudFront invalidation $invalidation to complete"
+    echo "   Ctrl-C to stop waiting."
+    aws cloudfront wait invalidation-completed \
+        --distribution-id "$distribution" \
+        --id "$invalidation"
+}
+
+main "$@"

--- a/ingest/bin/upload-to-s3
+++ b/ingest/bin/upload-to-s3
@@ -19,6 +19,7 @@ main() {
 
     local src="${1:?A source file is required as the first argument.}"
     local dst="${2:?A destination s3:// URL is required as the second argument.}"
+    local cloudfront_domain="${3:-}"
 
     local s3path="${dst#s3://}"
     local bucket="${s3path%%/*}"
@@ -37,6 +38,13 @@ main() {
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
+
+        if [[ -n $cloudfront_domain ]]; then
+            echo "Creating CloudFront invalidation for $cloudfront_domain/$key"
+            if ! "$bin"/cloudfront-invalidate "$cloudfront_domain" "/$key"; then
+                echo "CloudFront invalidation failed, but exiting with success anyway."
+            fi
+        fi
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."

--- a/ingest/config/optional.yaml
+++ b/ingest/config/optional.yaml
@@ -19,6 +19,7 @@ upload:
       'metadata.tsv.gz',
       'sequences.fasta.xz'
     ]
+    cloudfront_domain: 'data.nextstrain.org'
 
 # Toggle for Slack notifications
 send_slack_notifications: True

--- a/ingest/workflow/snakemake_rules/upload.smk
+++ b/ingest/workflow/snakemake_rules/upload.smk
@@ -21,8 +21,9 @@ rule upload_to_s3:
         touch("data/upload/s3/{file_to_upload}-to-{remote_file_name}.done")
     params:
         quiet = "" if send_notifications else "--quiet",
-        s3_dst = config["upload"].get("s3", {}).get("dst", "")
+        s3_dst = config["upload"].get("s3", {}).get("dst", ""),
+        cloudfront_domain = config["upload"].get("s3", {}).get("cloudfront_domain", "")
     shell:
         """
-        ./bin/upload-to-s3 {params.quiet} {input:q} {params.s3_dst:q}/{wildcards.remote_file_name:q}
+        ./bin/upload-to-s3 {params.quiet} {input:q} {params.s3_dst:q}/{wildcards.remote_file_name:q} {params.cloudfront_domain}
         """


### PR DESCRIPTION
Invalidate CloudFront after file has been uploaded to S3 so that we serve latest file at data.nextstrain.org.

(Adding the same CloudFront invalidation in [ncov-ingest](https://github.com/nextstrain/ncov-ingest/pull/315))