### PR TITLE
Add recency colouring (sequence submission)

### DIFF
--- a/config/auspice_config_hmpxv1.json
+++ b/config/auspice_config_hmpxv1.json
@@ -40,6 +40,16 @@
       "key": "dinuc_context_fraction",
       "title": "NGA/TCN context of G→A/C→T mutations",
       "type": "continuous"
+    },    
+    {
+      "key": "recency",
+      "title": "Submission Recency",
+      "type": "categorical"
+    },
+    {
+      "key": "date_submitted",
+      "title": "Submission Date",
+      "type": "categorical"
     },
     {
       "key": "genbank_accession_rev",

--- a/config/auspice_config_mpxv.json
+++ b/config/auspice_config_mpxv.json
@@ -47,6 +47,16 @@
       "type": "continuous"
     },
     {
+      "key": "recency",
+      "title": "Submission Recency",
+      "type": "categorical"
+    },
+    {
+      "key": "date_submitted",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
       "key": "genbank_accession_rev",
       "title": "Accession",
       "type": "categorical"

--- a/config/colors.tsv
+++ b/config/colors.tsv
@@ -4,3 +4,10 @@ region	Europe	#BEBB48
 region	North America	#E2562B
 region	Oceania	#5EA9A1
 region	South America	#E29E39
+
+recency	Older	#447CCD
+recency	One month ago	#5EA9A1
+recency	One week ago	#8ABB6A
+recency	3-7 days ago	#BEBB48
+recency	1-2 days ago	#E29E39
+recency	New	#E2562B

--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -26,6 +26,9 @@ seed_spacing: 1000
 timetree: true
 root: "MK783032 MK783030"
 
+## recency
+recency: true
+
 mask:
   from_beginning: 1500
   from_end: 7000

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -28,6 +28,9 @@ root: "min_dev"
 clock_rate: 3e-6
 clock_std_dev: 6e-6
 
+## recency
+recency: true
+
 mask:
   from_beginning: 1500
   from_end: 7000

--- a/scripts/construct-recency-from-submission-date.py
+++ b/scripts/construct-recency-from-submission-date.py
@@ -1,0 +1,46 @@
+import argparse
+from datetime import datetime
+from augur.io import read_metadata
+import json
+
+## Script originally from https://github.com/nextstrain/ncov/blob/master/scripts/construct-recency-from-submission-date.py
+
+def get_recency(date_str, ref_date):
+    date_submitted = datetime.strptime(date_str, '%Y-%m-%d').toordinal()
+    ref_day = ref_date.toordinal()
+
+    delta_days = ref_day - date_submitted
+    if delta_days<=0:
+        return 'New'
+    elif delta_days<3:
+        return '1-2 days ago'
+    elif delta_days<8:
+        return '3-7 days ago'
+    elif delta_days<15:
+        return 'One week ago'
+    elif delta_days<31:
+        return 'One month ago'
+    elif delta_days>=31:
+        return 'Older'
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Assign each sequence a field that specifies when it was added",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--metadata', type=str, required=True, help="metadata file")
+    parser.add_argument('--output', type=str, required=True, help="output json")
+    args = parser.parse_args()
+
+    meta = read_metadata(args.metadata).to_dict(orient="index")
+
+    node_data = {'nodes':{}}
+    ref_date = datetime.now()
+
+    for strain, d in meta.items():
+        if 'date_submitted' in d and d['date_submitted'] and d['date_submitted'] != "undefined":
+            node_data['nodes'][strain] = {'recency': get_recency(d['date_submitted'], ref_date)}
+
+    with open(args.output, 'wt') as fh:
+        json.dump(node_data, fh)


### PR DESCRIPTION
Approach (including code & colours) taken from nextstrain/ncov.

Also included a colouring for `date_sumitted` (YYY-MM-DD format) as I
want this to be available when clicking on a tip. Currently this must
be a color-by which is an Auspice limitation.
