### PR TITLE
Include "accession" in metadata

### DIFF
--- a/config/auspice_config_hmpxv1.json
+++ b/config/auspice_config_hmpxv1.json
@@ -50,11 +50,6 @@
       "key": "date_submitted",
       "title": "Submission Date",
       "type": "categorical"
-    },
-    {
-      "key": "genbank_accession_rev",
-      "title": "Accession",
-      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/config/auspice_config_mpxv.json
+++ b/config/auspice_config_mpxv.json
@@ -55,11 +55,6 @@
       "key": "date_submitted",
       "title": "Submission Date",
       "type": "categorical"
-    },
-    {
-      "key": "genbank_accession_rev",
-      "title": "Accession",
-      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/scripts/wrangle_metadata.py
+++ b/scripts/wrangle_metadata.py
@@ -1,9 +1,6 @@
 import pandas as pd
 import argparse
 
-
-
-
 if __name__=="__main__":
     parser = argparse.ArgumentParser(
         description="remove time info",
@@ -19,6 +16,10 @@ if __name__=="__main__":
     if 'strain' in metadata.columns:
         metadata.rename(columns={'strain': 'strain_original'}, inplace=True)
 
-    metadata.rename(columns={args.strain_id: 'strain'}, inplace=True)
+    # copy column, retaining original
+    # ie keep "accession" but also include "strain" with data from previous "accession" column
+    # insert this as the first column in the dataframe
+    metadata.insert(0, "strain", metadata[args.strain_id])
+    # metadata["strain"] = metadata[args.strain_id]
 
     metadata.to_csv(args.output, sep='\t', index=False)


### PR DESCRIPTION
Rather than replacing "accession" with "strain" in the initial `wrangle_metadata.py` script, instead keep "accession" column and create an additional "strain" column. This will allow `export` rule to recognize this "accession" column and include field in tooltips.

Also, remove `genbank_accession_rev` as "Accession" coloring. Now "Accession" will be automatically recognized and displayed in tooltip without having to have a coloring provided.

