### PR TITLE
chore: make submission_date scale temporal, parallel to mpxv change

### DIFF
--- a/config/auspice_config_hmpxv1.json
+++ b/config/auspice_config_hmpxv1.json
@@ -12,6 +12,11 @@
   "build_url": "https://github.com/nextstrain/monkeypox",
   "colorings": [
     {
+      "key": "sample_date",
+      "title": "Sample Date",
+      "type": "temporal"
+    },   
+	{
       "key": "outbreak_associated",
       "title": "Outbreak Associated",
       "type": "categorical"


### PR DESCRIPTION
### Description of proposed changes
I mirrored the changes @jameshadfield made to mpxv build to hmpxv1 in #57 

I'm not quite sure what the effect is, nothing seems to have changed to my eyes. So maybe this is not supposed to be changed? It doesn't do any harm though, either.

@jameshadfield can you enlighten me what the temporal scale does differently than not specifying it?

### Testing
Ran it locally, looked good