### PR TITLE
feat: rename nextalign -> nextalign2 to work with base image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,4 +9,4 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
     with:
       env: |
-        NEXTSTRAIN_DOCKER_IMAGE: nextstrain/base:branch-nextalign-v2
+        NEXTSTRAIN_DOCKER_IMAGE: nextstrain/base

--- a/README.md
+++ b/README.md
@@ -8,27 +8,30 @@ This is the [Nextstrain](https://nextstrain.org) build for monkeypox virus. Outp
 
 Input sequences and metadata can be retrieved from data.nextstrain.org
 
- * [sequences.fasta.xz](https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz)
- * [metadata.tsv.gz](https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz)
+* [sequences.fasta.xz](https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz)
+* [metadata.tsv.gz](https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz)
 
 Note that these data are generously shared by many labs around the world.
 If you analyze and plan to publish using these data, please contact these labs first.
 
 Within the analysis pipeline, these data are fetched from data.nextstrain.org and written to `data/` with:
-```
-nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 . data/sequences.fasta data/metadata.tsv
+
+```bash
+nextstrain build --docker . data/sequences.fasta data/metadata.tsv
 ```
 
 ### Run analysis pipeline
 
 Run pipeline to produce "overview" tree for `/monkeypox/mpxv` with:
-```
-nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 --cpus 1 . --configfile config/config_mpxv.yaml
+
+```bash
+nextstrain build --docker --cpus 1 . --configfile config/config_mpxv.yaml
 ```
 
 Run pipeline to produce "outbreak" tree for `/monkeypox/hmpxv1` with:
-```
-nextstrain build --docker --image=nextstrain/base:branch-nextalign-v2 --cpus 1 . --configfile config/config_hmpxv1.yaml
+
+```bash
+nextstrain build --docker --cpus 1 . --configfile config/config_hmpxv1.yaml
 ```
 
 Adjust the number of CPUs to what your machine has available you want to perform alignment and tree building a bit faster.
@@ -36,7 +39,8 @@ Adjust the number of CPUs to what your machine has available you want to perform
 ### Visualize results
 
 View results with:
-```
+
+```bash
 nextstrain view auspice/
 ```
 
@@ -59,25 +63,32 @@ uncertain.
 ## Installation
 
 Follow the [standard installation instructions](https://docs.nextstrain.org/en/latest/install.html) for Nextstrain's suite of software tools.
-Please choose the installation method for your operating system which uses Docker, as currently a pre-release version of Nextalign is required which we've baked into the `--image` argument to `nextstrain build` above.
+Please choose the installation method for your operating system which uses Docker, as currently the pre-release version 2 of Nextalign and Nextclade is required which we've baked into `nexstrain/base` docker image.
 
 ### Nextstrain build vs Snakemake
 
 The above commands use the Nextstrain CLI and `nextstrain build` along with Docker to run using Nextalign v2.
-Alternatively, if you [install Nextalign v2 locally](github.com/nextstrain/nextclade/releases) you can run pipeline with:
-```
+Alternatively, if you [install Nextalign/Nextclade v2 locally](github.com/nextstrain/nextclade/releases) you can run the pipeline with:
+
+```bash
 snakemake -j 1 -p --configfile config/config_mpxv.yaml
 snakemake -j 1 -p --configfile config/config_hmpxv1.yaml
 ```
+
+But you need to call the executable `nextalign2` and `nextclade2` respectively - since that's what they are called in the docker image.
+
 ### Update colors to include new countries
 
 Update `colors_hmpxv1.tsv` to group countries by region based on countries present in its `metadata.tsv`:
-```
+
+```bash
 python3 scripts/update_colours.py --colors config/colors_hmpxv1.tsv \
     --metadata results/hmpxv1/metadata.tsv --output config/colors_hmpxv1.tsv
 ```
+
 and similarly update `colors_mpxv.tsv`:
-```
+
+```bash
 python3 scripts/update_colours.py --colors config/colors_mpxv.tsv \
     --metadata results/mpxv/metadata.tsv --output config/colors_mpxv.tsv
 ```

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -7,7 +7,6 @@ This is the ingest pipeline for Monkeypox virus sequences.
 > NOTE: All command examples assume you are within the `ingest` directory.
 > If running commands from the outer `monkeypox` directory, please replace the `.` with `ingest`
 
-
 Fetch sequences with
 
 ```sh
@@ -19,6 +18,7 @@ Run the complete ingest pipeline with
 ```sh
 nextstrain build --cpus 1 .
 ```
+
 This will produce two files (within the `ingest` directory):
 
 - data/metadata.tsv
@@ -37,6 +37,7 @@ nextstrain build . --configfiles config/config.yaml config/optional.yaml
 Do the following to include sequences from static FASTA files.
 
 1. Convert the FASTA files to NDJSON files with:
+
     ```sh
     ./ingest/bin/fasta-to-ndjson \
         --fasta {path-to-fasta-file} \
@@ -45,10 +46,13 @@ Do the following to include sequences from static FASTA files.
         --exclude {fields-to-exclude-in-output} \
         > ingest/data/{file-name}.ndjson
     ```
+
 2. Add the following to the `.gitignore` to allow the file to be included in the repo:
-    ```
+
+    ```gitignore
     !ingest/data/{file-name}.ndjson
     ```
+
 3. Add the `file-name` (without the `.ndjson` extension) as a source to `ingest/config/config.yaml`. This will tell the ingest pipeline to concatenate the records to the GenBank sequences and run them through the same transform pipeline.
 
 ## Configuration

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -81,7 +81,7 @@ rule align:
     threads: workflow.cores
     shell:
         """
-        nextalign run \
+        nextalign2 run \
             --jobs {threads} \
             --reference {input.reference} \
             --max-indel {params.max_indel} \


### PR DESCRIPTION
### Description of proposed changes
Switch docker image from special nextalign-v2 to base image so that we don't can live on master again.

@tsibley has aliased nextalign/clade v2 as nextalign2/nextclade2 so this change of image requires minor edits.

This PR should cover them all, I tested that it works, I searched the repo systematically for uses of nextalign/nextclade and did a replacement - including in README.

This PR is necessary so that we can use nextclade-v2, so I'll merge it directly.
