### PR TITLE
feat: reverse complement sequences if annotated in metadata

### DIFF
--- a/config/auspice_config_hmpxv1.json
+++ b/config/auspice_config_hmpxv1.json
@@ -64,6 +64,8 @@
   "filters": [
     "country",
     "region",
+    "recency",
+    "outbreak_associated",
     "host"
   ]
 }

--- a/scripts/reverse_reversed_sequences.py
+++ b/scripts/reverse_reversed_sequences.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import argparse
+from Bio import SeqIO
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(
+        description="Reverse-complement reverse-complemented sequence",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--metadata', type=str, required=True, help="input metadata")
+    parser.add_argument('--sequences', type=str, required=True, help="input sequences")
+    parser.add_argument('--output', type=str, required=True, help="output sequences")
+    args = parser.parse_args()
+
+    metadata = pd.read_csv(args.metadata, sep='\t')
+    
+    # Read in fasta file
+    with open(args.sequences, 'r') as f_in:
+        with open(args.output, 'w') as f_out:
+            for seq in SeqIO.parse(f_in, 'fasta'):
+                # Check if metadata['reverse'] is True
+                try:
+                    if metadata.loc[metadata['strain'] == seq.id, 'reverse'].values[0] == True:
+                        # Reverse-complement sequence
+                        seq.seq = seq.seq.reverse_complement()
+                        print("Reverse-complementing sequence:", seq.id)
+                except:
+                    print("No reverse complement for:", seq.id)
+                    
+                # Write sequences to file
+                SeqIO.write(seq, f_out, 'fasta')

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -63,6 +63,18 @@ rule filter:
             --output-log {output.log}
         """
 
+rule separate_reverse_complement:
+    input:
+        metadata = build_dir + "/{build_name}/metadata.tsv",
+        sequences =  build_dir + "/{build_name}/filtered.fasta",
+    output: build_dir + "/{build_name}/reversed.fasta",
+    shell: """
+        python3 scripts/reverse_reversed_sequences.py \
+            --metadata {input.metadata} \
+            --sequences {input.sequences} \
+            --output {output}
+        """
+
 rule align:
     message:
         """
@@ -70,7 +82,7 @@ rule align:
           - filling gaps with N
         """
     input:
-        sequences = rules.filter.output.sequences,
+        sequences = rules.separate_reverse_complement.output,
         reference = config["reference"]
     output:
         alignment = build_dir + "/{build_name}/aligned.fasta",


### PR DESCRIPTION
Allows reverse complementing of sequences if metadata contains a column `reverse` with content `True`.

This is the build part, ingest is adapted in #79 