### PR TITLE
Change of reference, shorter ITR

### DIFF
--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -31,5 +31,5 @@ recency: true
 
 mask:
   from_beginning: 1500
-  from_end: 7000
+  from_end: 6422
   maskfile: "config/mask.bed"

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -33,5 +33,5 @@ recency: true
 
 mask:
   from_beginning: 1500
-  from_end: 7000
+  from_end: 6422
   maskfile: "config/mask_overview.bed"


### PR DESCRIPTION
Hi,

- The reference is NC_063383

- I found that some real mutation (G190660A in the NC_063383 coordinates, G190675A in previous UK_P2 coordinates) [disappearead from the tree](https://nextstrain.org/monkeypox/hmpxv1?c=gt-nuc_190660&label=clade:B.1&m=div)
- This is because you are masking the 7000 nucleotides at the end, that is 190210:197209  in NC_063383 coordinates
- Whereas to me the ITR is 190788:197209  
- Whence I propose to replace 7000 by 6422 = 197209-190788+1


Alignment around the real G190600A mutation

![image](https://user-images.githubusercontent.com/6537565/175939154-d24fe86d-055f-446e-b1f7-8bf1e7193c32.png)

Blast saying that the ITR starts at 190788

![image](https://user-images.githubusercontent.com/6537565/175939835-0befdf13-6aaf-4733-b4cd-0ba80aebfe86.png)

The mutation in my tree

![image](https://user-images.githubusercontent.com/6537565/175940751-48bcf12a-e429-4b89-a1e9-0ed5ff225311.png)
