### PR TITLE
fix: duplicate metadata output from chores

### DIFF
--- a/workflow/snakemake_rules/chores.smk
+++ b/workflow/snakemake_rules/chores.smk
@@ -9,13 +9,14 @@ rule update_example_data:
 
     TODO: Use `strain` as the ID column after https://github.com/nextstrain/monkeypox/issues/33 is done.
     """
-    message: "Update example data"
+    message:
+        "Update example data"
     input:
-        sequences = "data/sequences.fasta",
-        metadata = "data/metadata.tsv"
+        sequences="data/sequences.fasta",
+        metadata="data/metadata.tsv",
     output:
-        sequences = "example_data/sequences.fasta",
-        metadata = "example_data/metadata.tsv"
+        sequences="example_data/sequences.fasta",
+        metadata="example_data/metadata.tsv",
     shell:
         """
         augur filter \
@@ -28,4 +29,7 @@ rule update_example_data:
             --subsample-seed 0 \
             --output-metadata {output.metadata} \
             --output-sequences {output.sequences}
+        cp {output.metadata} /tmp/metadata-pipe
+        tsv-uniq /tmp/metadata-pipe > {output.metadata}
+        rm /tmp/metadata-pipe
         """


### PR DESCRIPTION
### Description of proposed changes
Fixes problem that there's duplicate metadata produced by chores.smk, see https://github.com/nextstrain/monkeypox/pull/86#issuecomment-1169098568