### PR TITLE
Subsample MPXV clades

### DIFF
--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -17,6 +17,7 @@ auspice_name: "monkeypox_hmpxv1"
 ## filter
 min_date: 2017
 min_length: 10000
+sequences_per_group: 1000
 filters: "--exclude-where clade!=hMPXV-1"
 
 ## align

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -17,6 +17,7 @@ auspice_name: "monkeypox_mpxv"
 ## filter
 min_date: 1950
 min_length: 10000
+sequences_per_group: 100
 
 ## align
 max_indel: 10000

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -44,8 +44,8 @@ rule filter:
         metadata = build_dir + "/{build_name}/metadata.tsv",
         log = build_dir + "/{build_name}/filtered.log"
     params:
-        group_by = "country year",
-        sequences_per_group = 1000,
+        group_by = "clade lineage",
+        sequences_per_group = config['sequences_per_group'],
         min_date = config['min_date'],
         min_length = config['min_length'],
         other_filters = config.get("filters", "")


### PR DESCRIPTION
### Description of proposed changes

As more and more B.1 viruses are sequenced, the MPXV global diversity tree is becoming increasingly lopsided and not very descriptive of broader diversity.

This commit updates filter to subsample based on `clade lineage` so that every clade / lineage combination is subsampled to. It sets sequences per group to 1000 for hMPXV so that no subsampling occurs and sets sequences per group to 100 for MPXV, which effectively just subsamples B.1 from 289 genomes to 100.

Here's what the MPXV build looks like with this subsampling in place:

![Screen Shot 2022-07-06 at 5 44 58 PM](https://user-images.githubusercontent.com/1176109/177666093-ac9627f7-a258-47d4-946c-2c5ee99fd118.png)

Build visible here: https://next.nextstrain.org/staging/monkeypox/mpxv/subsample-mpxv-clades

I think this subsampling will be increasingly important for the `mpxv` page as more B.1* genomes come in.
