### PR TITLE
clades: Proposal to designate 5 B.1 sublineages (B.1.1 - B.1.5)

### DIFF
--- a/config/clades.tsv
+++ b/config/clades.tsv
@@ -43,9 +43,3 @@ B.1.4	nuc	34308	A
 
 B.1.5	clade	B.1
 B.1.5	nuc	70780	T
-
-B.1.6	clade	B.1
-B.1.6	nuc	25644	T
-
-B.1.7	clade	B.1
-B.1.7	nuc	14611	A

--- a/config/clades.tsv
+++ b/config/clades.tsv
@@ -36,16 +36,16 @@ B.1.2	clade	B.1
 B.1.2	nuc	186165	A
 
 B.1.3	clade	B.1
-B.1.3	nuc	34308	A
+B.1.3	nuc	190660	A
 
 B.1.4	clade	B.1
-B.1.4	nuc	190660	A
+B.1.4	nuc	34308	A
 
 B.1.5	clade	B.1
 B.1.5	nuc	70780	T
 
 B.1.6	clade	B.1
-B.1.6	nuc	14611	A
+B.1.6	nuc	25644	T
 
 B.1.7	clade	B.1
-B.1.7	nuc	25644	T
+B.1.7	nuc	14611	A

--- a/config/clades.tsv
+++ b/config/clades.tsv
@@ -48,32 +48,4 @@ B.1.6	clade	B.1
 B.1.6	nuc	14611	A
 
 B.1.7	clade	B.1
-# Homoplasic, problematic, but kept in place of 63147
 B.1.7	nuc	25644	T
-
-B.1.8	clade	B.1
-B.1.8	nuc	156429	T
-
-B.1.9	clade	B.1
-B.1.9	nuc	5595	A
-
-B.1.10	clade	B.1
-B.1.10	nuc	36617	A
-B.1.10	nuc	159779	T
-
-B.1.11	clade	B.1
-B.1.11	nuc	181367	A
-
-B.1.12	clade	B.1
-B.1.12	nuc	169928	A
-
-B.1.13	clade	B.1
-B.1.13	nuc	111084	A
-B.1.13	nuc	182950	T
-
-B.1.14	clade	B.1
-B.1.14	nuc	89906	T
-
-# Homoplasic, removed for now
-#B.1.15	clade	B.1
-#B.1.15	nuc	63147	A

--- a/config/clades.tsv
+++ b/config/clades.tsv
@@ -28,3 +28,52 @@ A.1.1	nuc	34459	A
 
 B.1	clade	A.1.1
 B.1	nuc	77383	A
+
+B.1.1	clade	B.1
+B.1.1	nuc	74360	A
+
+B.1.2	clade	B.1
+B.1.2	nuc	186165	A
+
+B.1.3	clade	B.1
+B.1.3	nuc	34308	A
+
+B.1.4	clade	B.1
+B.1.4	nuc	190660	A
+
+B.1.5	clade	B.1
+B.1.5	nuc	70780	T
+
+B.1.6	clade	B.1
+B.1.6	nuc	14611	A
+
+B.1.7	clade	B.1
+# Homoplasic, problematic, but kept in place of 63147
+B.1.7	nuc	25644	T
+
+B.1.8	clade	B.1
+B.1.8	nuc	156429	T
+
+B.1.9	clade	B.1
+B.1.9	nuc	5595	A
+
+B.1.10	clade	B.1
+B.1.10	nuc	36617	A
+B.1.10	nuc	159779	T
+
+B.1.11	clade	B.1
+B.1.11	nuc	181367	A
+
+B.1.12	clade	B.1
+B.1.12	nuc	169928	A
+
+B.1.13	clade	B.1
+B.1.13	nuc	111084	A
+B.1.13	nuc	182950	T
+
+B.1.14	clade	B.1
+B.1.14	nuc	89906	T
+
+# Homoplasic, removed for now
+#B.1.15	clade	B.1
+#B.1.15	nuc	63147	A


### PR DESCRIPTION
## Proposal to designate 5 B.1 sublineages

Lineages are defined by at least one shared nucleotide mutation on top of the B.1 polytomy.

In this first round of sublineage designations, the clusters with the highest number of sequences publicly available via Genbank are chosen.

It is important to bear in mind that the proportion of cases sequenced with sequences shared via Genbank differs hugely among countries. Germany has sequenced ~10% of their known cases. While for instance the Netherlands have only shared one sequence publicly, for 500 known cases (0.2%), a proportion 50x smaller than Germany's.

As a result, lineages are disproportionately associated with those countries that sequence most (currently Germany and Canada). Lineages should not be used on their own without other metadata to draw epidemiological conclusions.
 
These lineages have been designated to enable researchers to track the virus on a finer scale. Their designation does not imply any biological difference. For example, B.1.4 differs from B.1 only by a synonymous mutation - the proteins are thus all identical.

### Testing

Staging build deployed here: https://nextstrain.org/staging/monkeypox/hmpxv1/lineage-proposal?label=clade:B.1&m=div
