### PR TITLE
ingest: Update schedule to run daily at 4pm UTC

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -16,7 +16,9 @@ on:
     #
     # Tool that deciphers this particular format of crontab string:
     #  - https://crontab.guru/
-    - cron:  '0 * * * *'
+    #
+    # Runs at 4pm UTC (12pm EDT) since curation by NCBI happens on the East Coast.
+    - cron:  '0 16 * * *'
 
   repository_dispatch:
     types:


### PR DESCRIPTION
During the internal Nextstrain meeting on July 21, 2022, the team
decided to reduce the monkeypox/ingest pipeline to run only once a day
to reduce bombardment of Slack messages.

Through Slack discussion¹, we decided to run it daily at 12pm ET since
the curation by NCBI is done on the East Coast.

¹ https://bedfordlab.slack.com/archives/C03G8HQEV18/p1658860515668579
