### PR TITLE
Ingest cleanup

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -40,6 +40,7 @@ def _get_all_targets(wildcards):
     if send_slack_notifications:
         all_targets.extend([
             "data/notify/genbank-record-change.done",
+            "data/notify/metadata-diff.done",
         ])
 
 

--- a/ingest/bin/download-from-s3
+++ b/ingest/bin/download-from-s3
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Originally copied from nextstrain/ncov-ingest repo
+set -euo pipefail
+
+bin="$(dirname "$0")"
+
+main() {
+    local src="${1:?A source s3:// URL is required as the first argument.}"
+    local dst="${2:?A destination file path is required as the second argument.}"
+
+    local s3path="${src#s3://}"
+    local bucket="${s3path%%/*}"
+    local key="${s3path#*/}"
+
+    local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
+    dst_hash="$("$bin/sha256sum" < "$dst" || true)"
+    src_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+
+    echo "[ INFO] Downloading $src → $dst"
+    if [[ $src_hash != "$dst_hash" ]]; then
+        aws s3 cp --no-progress "$src" - |
+        if [[ "$src" == *.gz ]]; then
+            gunzip -cfq
+        elif  [[ "$src" == *.xz ]]; then
+            xz -T0 -dcq
+        else
+            cat
+        fi > "$dst"
+    else
+        echo "[ INFO] Files are identical, skipping download"
+    fi
+}
+
+main "$@"

--- a/ingest/bin/genbank-url
+++ b/ingest/bin/genbank-url
@@ -51,9 +51,9 @@ params = {
         ]
     ),
 
-    # Stable sort with newest last so diffs work nicely.  Columns are source
-    # data fields, not our output columns.
-    'sort': 'SourceDB_s desc, CollectionDate_s asc, id asc',
+    # Stable sort with GenBank accessions.
+    # Columns are source data fields, not our output columns.
+    'sort': 'id asc',
 
     # This isn't Entrez, but include the same email parameter it requires just
     # to be nice.

--- a/ingest/bin/notify-on-diff
+++ b/ingest/bin/notify-on-diff
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+bin="$(dirname "$0")"
+
+src="${1:?A source file is required as the first argument.}"
+dst="${2:?A destination s3:// URL is required as the second argument.}"
+
+dst_local="$(mktemp -t s3-file-XXXXXX)"
+diff="$(mktemp -t diff-XXXXXX)"
+
+trap "rm -f '$dst_local' '$diff'" EXIT
+
+# if the file is not already present, just exit
+"$bin"/s3-object-exists "$dst" || exit 0
+
+"$bin"/download-from-s3 "$dst" "$dst_local"
+
+# diff's exit code is 0 for no differences, 1 for differences found, and >1 for errors
+diff_exit_code=0
+diff "$dst_local" "$src" > "$diff" || diff_exit_code=$?
+
+if [[ "$diff_exit_code" -eq 1 ]]; then
+    echo "Notifying Slack about diff."
+    "$bin"/notify-slack --upload "$src.diff" < "$diff"
+elif [[ "$diff_exit_code" -gt 1 ]]; then
+    echo "Notifying Slack about diff failure"
+    "$bin"/notify-slack "Diff failed for $src"
+else
+    echo "No change in $src."
+fi

--- a/ingest/bin/notify-on-record-change
+++ b/ingest/bin/notify-on-record-change
@@ -14,8 +14,20 @@ source_name=${3:?A record source name is required as the third argument.}
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
+s3path="${dst#s3://}"
+bucket="${s3path%%/*}"
+key="${s3path#*/}"
+
 src_record_count="$(wc -l < "$src")"
-dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+
+# Try getting record count from S3 object metadata
+dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query "Metadata.recordcount || ''" --output text 2>/dev/null || true)"
+if [[ -z "$dst_record_count" ]]; then
+  # This object doesn't have the record count stored as metadata
+  # We have to download it and count the lines locally
+  dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+fi
+
 added_records="$(( src_record_count - dst_record_count ))"
 
 printf "%'4d %s\n" "$src_record_count" "$src"

--- a/ingest/bin/upload-to-s3
+++ b/ingest/bin/upload-to-s3
@@ -30,6 +30,9 @@ main() {
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     if [[ $src_hash != "$dst_hash" ]]; then
+        # The record count may have changed
+        src_record_count="$(wc -l < "$src")"
+
         echo "Uploading $src → $dst"
         if [[ "$dst" == *.gz ]]; then
             gzip -c "$src"
@@ -37,7 +40,7 @@ main() {
             xz -2 -T0 -c "$src"
         else
             cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
+        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
 
         if [[ -n $cloudfront_domain ]]; then
             echo "Creating CloudFront invalidation for $cloudfront_domain/$key"

--- a/ingest/workflow/snakemake_rules/slack_notifications.smk
+++ b/ingest/workflow/snakemake_rules/slack_notifications.smk
@@ -33,6 +33,18 @@ rule notify_on_genbank_record_change:
         """
 
 
+rule notify_on_metadata_diff:
+    input:
+        metadata = "data/metadata.tsv"
+    output:
+        touch("data/notify/metadata-diff.done")
+    params:
+        s3_src = S3_SRC
+    shell:
+        """
+        ./bin/notify-on-diff {input.metadata} {params.s3_src:q}/metadata.tsv.gz
+        """
+
 onstart:
     shell("./bin/notify-on-job-start")
 

--- a/ingest/workflow/snakemake_rules/upload.smk
+++ b/ingest/workflow/snakemake_rules/upload.smk
@@ -30,8 +30,14 @@ def _get_upload_inputs(wildcards):
     }
 
     if send_notifications:
+        flag_file = []
+
         if file_to_upload == "genbank.ndjson":
-            inputs["notify_flag_file"] = "data/notify/genbank-record-change.done"
+            flag_file = "data/notify/genbank-record-change.done"
+        elif file_to_upload == "metadata.tsv":
+            flag_file = "data/notify/metadata-diff.done"
+
+        inputs["notify_flag_file"] = flag_file
 
     return inputs
 


### PR DESCRIPTION
### Description of proposed changes
Small improvements for ingest:
- store record count in S3 object metadata (taken from https://github.com/nextstrain/ncov-ingest/pull/316)
- sort GenBank records by accession for stable sorting
- remove race condition between diff notifications and S3 uploads
- notify Slack w/ metadata diff (Resolves #77)

### Testing
- [x] Tested locally
      - [metadata diff output](https://github.com/nextstrain/monkeypox/files/9202863/metadata.tsv.diff.txt) from changing sorting order
- [x] Test run on [AWS Batch](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/71eebdec-4e74-4e10-846e-c3ad18303606)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
