### PR TITLE
Automate rebuilds

### DIFF
--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -1,0 +1,47 @@
+name: Rebuild hmpxv1
+
+on:
+  repository_dispatch:
+    types:
+      - rebuild
+      - rebuild_hmpxv1
+
+  workflow_dispatch:
+
+jobs:
+  rebuild_mpxv:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_RUN_ID: ${{ github.run_id }}
+      SLACK_CHANNELS: monkeypox-updates
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+    - name: launch_build
+      run: |
+        ./bin/write-envdir env.d \
+          AWS_DEFAULT_REGION \
+          GITHUB_RUN_ID \
+          SLACK_TOKEN \
+          SLACK_CHANNELS
+
+        nextstrain build \
+          --aws-batch \
+          --detach \
+          --no-download \
+          --exec env \
+          . \
+            envdir env.d snakemake notify_on_deploy \
+              --configfiles config/config_hmpxv1.yaml config/nextstrain_automation.yaml \
+              --printshellcmds
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: notify_pipeline_failed
+      if: ${{ failure() }}
+      run: ./bin/notify-on-error
+

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -1,0 +1,47 @@
+name: Rebuild mpxv
+
+on:
+  repository_dispatch:
+    types:
+      - rebuild
+      - rebuild_mpxv
+
+  workflow_dispatch:
+
+jobs:
+  rebuild_mpxv:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_RUN_ID: ${{ github.run_id }}
+      SLACK_CHANNELS: monkeypox-updates
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+    - name: launch_build
+      run: |
+        ./bin/write-envdir env.d \
+          AWS_DEFAULT_REGION \
+          GITHUB_RUN_ID \
+          SLACK_TOKEN \
+          SLACK_CHANNELS
+
+        nextstrain build \
+          --aws-batch \
+          --detach \
+          --no-download \
+          --exec env \
+          . \
+            envdir env.d snakemake notify_on_deploy \
+              --configfiles config/config_mpxv.yaml config/nextstrain_automation.yaml \
+              --printshellcmds
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: notify_pipeline_failed
+      if: ${{ failure() }}
+      run: ./bin/notify-on-error
+

--- a/Snakefile
+++ b/Snakefile
@@ -42,6 +42,9 @@ include: "workflow/snakemake_rules/chores.smk"
 
 include: "workflow/snakemake_rules/core.smk"
 
+if config.get("deploy_url"):
+    include: "workflow/snakemake_rules/nextstrain_automation.smk"
+
 
 rule clean:
     message: "Removing directories: {params}"

--- a/bin/notify-on-deploy
+++ b/bin/notify-on-deploy
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+base="$(realpath "$(dirname "$0")/..")"
+ingest_bin="$base/ingest/bin"
+
+deployment_url="${1:?A deployment url is required as the first argument.}"
+slack_ts_file="${2:?A Slack thread timestamp file is required as the second argument.}"
+
+echo "Notifying Slack about deployed builds."
+"$ingest_bin"/notify-slack "Deployed this build to $deployment_url" \
+    --thread-ts="$(cat "$slack_ts_file")"

--- a/bin/notify-on-error
+++ b/bin/notify-on-error
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+: "${AWS_BATCH_JOB_ID:=}"
+: "${GITHUB_RUN_ID:=}"
+
+base="$(realpath "$(dirname "$0")/..")"
+ingest_bin="$base/ingest/bin"
+
+slack_ts_file="${1:-}"
+
+echo "Notifying Slack about successful build."
+
+thread_ts=""
+message="❌ Monkepox build pipeline has FAILED 😞."
+
+if [[ -n "$slack_ts_file" ]]; then
+  thread_ts=$(cat "$slack_ts_file")
+  message+=" Please see linked thread for more information."
+elif [[ -n "${AWS_BATCH_JOB_ID}" ]]; then
+  message+="See AWS Batch job \`${AWS_BATCH_JOB_ID}\` (<https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/detail/${AWS_BATCH_JOB_ID}|link>) for error details."
+elif [[ -n "${GITHUB_RUN_ID}" ]]; then
+  message+="See GitHub Action <https://github.com/nextstrain/monkeypox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}> for error details."
+fi
+
+"$ingest_bin"/notify-slack "$message" \
+  --thread-ts="$thread_ts" \
+  --broadcast

--- a/bin/notify-on-start
+++ b/bin/notify-on-start
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+: "${AWS_BATCH_JOB_ID:=}"
+: "${GITHUB_RUN_ID:=}"
+
+base="$(realpath "$(dirname "$0")/..")"
+ingest_bin="$base/ingest/bin"
+
+build_name="${1:?A build name is required as the first argument.}"
+slack_ts_output="${2:?A Slack thread timestamp file is required as the second argument}"
+
+slack_response="$(mktemp -t slack-response-XXXXXX)"
+
+trap "rm -f '$slack_response'" EXIT
+
+echo "Notifying Slack about starting build."
+message="Pipeline starting for the \`$build_name\` build, which will run the phylogenetics and deploy the build."
+
+if [[ -n "${GITHUB_RUN_ID}" ]]; then
+  message+=" The job was submitted by GitHub Action <https://github.com/nextstrain/monkeypox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}>."
+fi
+
+if [[ -n "${AWS_BATCH_JOB_ID}" ]]; then
+  message+=" The job was launched as AWS Batch job \`${AWS_BATCH_JOB_ID}\` (<https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/detail/${AWS_BATCH_JOB_ID}|link>)."
+  message+=" Follow along in your local \`monkeypox\` repo with: "'```'"nextstrain build --aws-batch --no-download --attach ${AWS_BATCH_JOB_ID} . "'```'
+fi
+
+"$ingest_bin"/notify-slack "$message" --output="$slack_response"
+
+echo "Saving Slack thread timestamp to '$slack_ts_output'."
+
+# Create the Slack ts file if it doesn't exist
+if [[ ! -f "$slack_ts_output" ]]; then
+  mkdir -p "${slack_ts_output%/*}" && touch "$slack_ts_output"
+fi
+
+jq '.ts' < "$slack_response" > "$slack_ts_output"

--- a/bin/notify-on-success
+++ b/bin/notify-on-success
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+: "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
+
+base="$(realpath "$(dirname "$0")/..")"
+ingest_bin="$base/ingest/bin"
+
+slack_ts_file="${1:?A Slack thread timestamp file is required as the first argument.}"
+
+echo "Notifying Slack about successful build."
+"$ingest_bin"/notify-slack "✅ This pipeline has successfully finished 🎉" \
+  --thread-ts="$(cat "$slack_ts_file")"

--- a/config/nextstrain_automation.yaml
+++ b/config/nextstrain_automation.yaml
@@ -1,0 +1,5 @@
+# Optional configs to include for automated Nextstrain builds
+# Intended to be used internally by the Nextstrain team
+
+# deploy
+deploy_url: "s3://nextstrain-staging"

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -43,6 +43,8 @@ def _get_all_targets(wildcards):
             "data/notify/metadata-diff.done",
         ])
 
+    if config.get("trigger_rebuild"):
+        all_targets.append("data/trigger/rebuild.done")
 
     return all_targets
 
@@ -61,3 +63,6 @@ if config.get("upload"):
 
 if send_slack_notifications:
     include: "workflow/snakemake_rules/slack_notifications.smk"
+
+if config.get("trigger_rebuild"):
+    include: "workflow/snakemake_rules/trigger_rebuild.smk"

--- a/ingest/bin/notify-slack
+++ b/ingest/bin/notify-slack
@@ -6,12 +6,21 @@ set -euo pipefail
 : "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
 
 upload=0
+output=/dev/null
+thread_ts=""
+broadcast=0
 args=()
 
 for arg; do
     case "$arg" in
         --upload)
             upload=1;;
+        --output=*)
+            output="${arg#*=}";;
+        --thread-ts=*)
+            thread_ts="${arg#*=}";;
+        --broadcast)
+            broadcast=1;;
         *)
             args+=("$arg");;
     esac
@@ -28,18 +37,22 @@ if [[ "$upload" == 1 ]]; then
         --form-string channels="$SLACK_CHANNELS" \
         --form-string title="$text" \
         --form-string filename="$text" \
+        --form-string thread_ts="$thread_ts" \
+        --form-string reply_broadcast="$broadcast" \
         --form file=@/dev/stdin \
         --form filetype=text \
         --fail --silent --show-error \
         --http1.1 \
-        --output /dev/null
+        --output "$output"
 else
     echo "Posting Slack message: $text"
     curl https://slack.com/api/chat.postMessage \
         --header "Authorization: Bearer $SLACK_TOKEN" \
         --form-string channel="$SLACK_CHANNELS" \
         --form-string text="$text" \
+        --form-string thread_ts="$thread_ts" \
+        --form-string reply_broadcast="$broadcast" \
         --fail --silent --show-error \
         --http1.1 \
-        --output /dev/null
+        --output "$output"
 fi

--- a/ingest/bin/trigger
+++ b/ingest/bin/trigger
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PAT_GITHUB_DISPATCH:=}"
+
+repo="${1:?A repository name is required as the first argument.}"
+event_type="${2:?An event type is required as the second argument.}"
+shift 2
+
+if [[ $# -eq 0 && -z $PAT_GITHUB_DISPATCH ]]; then
+    cat >&2 <<.
+You must specify options to curl for your GitHub credentials.  For example, you
+can specify your GitHub username, and will be prompted for your password:
+
+  $0 $repo $event_type --user <your-github-username>
+
+Be sure to enter a personal access token¹ as your password since GitHub has
+discontinued password authentication to the API starting on November 13, 2020².
+
+You can also store your credentials or a personal access token in a netrc
+file³:
+
+  machine api.github.com
+  login <your-username>
+  password <your-token>
+
+and then tell curl to use it:
+
+  $0 $repo $event_type --netrc
+
+which will then not require you to type your password every time.
+
+¹ https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+² https://docs.github.com/en/rest/overview/other-authentication-methods#via-username-and-password
+³ https://ec.haxx.se/usingcurl/usingcurl-netrc
+.
+    exit 1
+fi
+
+auth=':'
+if [[ -n $PAT_GITHUB_DISPATCH ]]; then
+  auth="Authorization: Bearer ${PAT_GITHUB_DISPATCH}"
+fi
+
+if curl -fsS "https://api.github.com/repos/nextstrain/${repo}/dispatches" \
+    -H 'Accept: application/vnd.github.v3+json' \
+    -H 'Content-Type: application/json' \
+    -H "$auth" \
+    -d '{"event_type":"'"$event_type"'"}' \
+    "$@"
+then
+    echo "Successfully triggered $event_type"
+else
+    echo "Request failed" >&2
+    exit 1
+fi

--- a/ingest/bin/trigger-on-new-data
+++ b/ingest/bin/trigger-on-new-data
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PAT_GITHUB_DISPATCH:?The PAT_GITHUB_DISPATCH environment variable is required.}"
+
+bin="$(dirname "$0")"
+
+metadata="${1:?A metadata upload output file is required as the first argument.}"
+sequences="${2:?An sequence FASTA upload output file is required as the second argument.}"
+identical_file_message="${3:-files are identical}"
+
+new_metadata=$(grep "$identical_file_message" "$metadata" >/dev/null; echo $?)
+new_sequences=$(grep "$identical_file_message" "$sequences" >/dev/null; echo $?)
+
+slack_message=""
+
+# grep exit status 0 for found match, 1 for no match, 2 if an error occurred
+if [[ $new_metadata -eq 1 || $new_sequences -eq 1 ]]; then
+    slack_message="Triggering new builds due to updated metadata and/or sequences"
+    "$bin"/trigger "monkeypox" "rebuild"
+elif [[ $new_metadata -eq 0 && $new_sequences -eq 0 ]]; then
+    slack_message="Skipping trigger of rebuild: Both metadata TSV and sequences FASTA are identical to S3 files."
+else
+    slack_message="Skipping trigger of rebuild: Unable to determine if data has been updated."
+fi
+
+
+if ! "$bin"/notify-slack "$slack_message"; then
+    echo "Notifying Slack failed, but exiting with success anyway."
+fi

--- a/ingest/config/optional.yaml
+++ b/ingest/config/optional.yaml
@@ -23,3 +23,6 @@ upload:
 
 # Toggle for Slack notifications
 send_slack_notifications: True
+
+# Toggle for triggering builds
+trigger_rebuild: True

--- a/ingest/workflow/snakemake_rules/trigger_rebuild.smk
+++ b/ingest/workflow/snakemake_rules/trigger_rebuild.smk
@@ -15,5 +15,5 @@ rule trigger_build:
         touch("data/trigger/rebuild.done")
     shell:
         """
-        ./bin/trigger monkeypox rebuild
+        ./bin/trigger-on-new-data {input.metadata_upload} {input.fasta_upload}
         """

--- a/ingest/workflow/snakemake_rules/trigger_rebuild.smk
+++ b/ingest/workflow/snakemake_rules/trigger_rebuild.smk
@@ -1,0 +1,19 @@
+"""
+This part of the workflow handles triggering new monkeypox builds after the
+latest metadata TSV and sequence FASTA files have been uploaded to S3.
+
+Designed to be used internally by the Nextstrain team with hard-coded paths
+to expected upload flag files.
+"""
+
+rule trigger_build:
+    message: "Triggering monekypox builds via repository action type `rebuild`."
+    input:
+        metadata_upload = "data/upload/s3/metadata.tsv-to-metadata.tsv.gz.done",
+        fasta_upload = "data/upload/s3/sequences.fasta-to-sequences.fasta.xz.done"
+    output:
+        touch("data/trigger/rebuild.done")
+    shell:
+        """
+        ./bin/trigger monkeypox rebuild
+        """

--- a/ingest/workflow/snakemake_rules/upload.smk
+++ b/ingest/workflow/snakemake_rules/upload.smk
@@ -46,12 +46,16 @@ rule upload_to_s3:
     input:
         unpack(_get_upload_inputs)
     output:
-        touch("data/upload/s3/{file_to_upload}-to-{remote_file_name}.done")
+        "data/upload/s3/{file_to_upload}-to-{remote_file_name}.done"
     params:
         quiet = "" if send_notifications else "--quiet",
         s3_dst = config["upload"].get("s3", {}).get("dst", ""),
         cloudfront_domain = config["upload"].get("s3", {}).get("cloudfront_domain", "")
     shell:
         """
-        ./bin/upload-to-s3 {params.quiet} {input.file_to_upload:q} {params.s3_dst:q}/{wildcards.remote_file_name:q} {params.cloudfront_domain}
+        ./bin/upload-to-s3 \
+            {params.quiet} \
+            {input.file_to_upload:q} \
+            {params.s3_dst:q}/{wildcards.remote_file_name:q} \
+            {params.cloudfront_domain} 2>&1 | tee {output}
         """

--- a/workflow/snakemake_rules/nextstrain_automation.smk
+++ b/workflow/snakemake_rules/nextstrain_automation.smk
@@ -27,3 +27,6 @@ rule deploy:
 onstart:
     # Saves onstart Slack message thread timestamp to file SLACK_TS_FILE
     shell(f"./bin/notify-on-start {config.get('build_name', 'unknown')} {SLACK_TS_FILE}")
+
+onsuccess:
+    shell(f"./bin/notify-on-success {SLACK_TS_FILE}")

--- a/workflow/snakemake_rules/nextstrain_automation.smk
+++ b/workflow/snakemake_rules/nextstrain_automation.smk
@@ -24,6 +24,19 @@ rule deploy:
         nextstrain remote upload {params.deploy_url} {input}
         """
 
+rule notify_on_deploy:
+    input:
+        deploy_flag = build_dir + f"/{BUILD_NAME}/deploy.done"
+    output:
+        touch(build_dir + f"/{BUILD_NAME}/notify_on_deploy.done")
+    params:
+        deploy_url = DEPLOY_URL,
+        slack_ts = SLACK_TS_FILE
+    shell:
+        """
+        ./bin/notify-on-deploy {params.deploy_url} {params.slack_ts}
+        """
+
 onstart:
     # Saves onstart Slack message thread timestamp to file SLACK_TS_FILE
     shell(f"./bin/notify-on-start {config.get('build_name', 'unknown')} {SLACK_TS_FILE}")

--- a/workflow/snakemake_rules/nextstrain_automation.smk
+++ b/workflow/snakemake_rules/nextstrain_automation.smk
@@ -30,3 +30,6 @@ onstart:
 
 onsuccess:
     shell(f"./bin/notify-on-success {SLACK_TS_FILE}")
+
+onerror:
+    shell(f"./bin/notify-on-error {SLACK_TS_FILE}")

--- a/workflow/snakemake_rules/nextstrain_automation.smk
+++ b/workflow/snakemake_rules/nextstrain_automation.smk
@@ -1,0 +1,24 @@
+"""
+This part of the workflow handles the bells and whistles for automated
+Nextstrain builds. Designed to be used internally by the Nextstrain team.
+
+This part of the workflow continues after the main workflow, so the first
+rule `deploy` expects input files from `rules.all.input`. It purposely uses the
+build name from the config instead of the wildcards so that the rules can be
+used as target rules without explicitly defining the output files.
+
+Requires `build_dir` to be defined upstream.
+"""
+BUILD_NAME= config["build_name"]
+DEPLOY_URL = config["deploy_url"]
+
+rule deploy:
+    input: *rules.all.input
+    output:
+        touch(build_dir + f"/{BUILD_NAME}/deploy.done")
+    params:
+        deploy_url = DEPLOY_URL
+    shell:
+        """
+        nextstrain remote upload {params.deploy_url} {input}
+        """

--- a/workflow/snakemake_rules/nextstrain_automation.smk
+++ b/workflow/snakemake_rules/nextstrain_automation.smk
@@ -11,6 +11,7 @@ Requires `build_dir` to be defined upstream.
 """
 BUILD_NAME= config["build_name"]
 DEPLOY_URL = config["deploy_url"]
+SLACK_TS_FILE = build_dir + f"/{BUILD_NAME}/slack_thread_ts.txt"
 
 rule deploy:
     input: *rules.all.input
@@ -22,3 +23,7 @@ rule deploy:
         """
         nextstrain remote upload {params.deploy_url} {input}
         """
+
+onstart:
+    # Saves onstart Slack message thread timestamp to file SLACK_TS_FILE
+    shell(f"./bin/notify-on-start {config.get('build_name', 'unknown')} {SLACK_TS_FILE}")


### PR DESCRIPTION
### Description of proposed changes
Automates rebuilds for `mpxv` and `hpmxv1` to run when there's new data from ingest. Includes threaded Slack replies for builds since we don't want to mix up Slack messages from the separate builds. (Note this is separate from #36, which is specifically for ingest). 

### Testing
Unfortunately cannot fully test the ingest trigger since [repository dispatch events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch) only trigger the workflow on the main branch. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
