### PR TITLE
Exclude potential recombinant Nigeria-78

### DIFF
--- a/config/exclude_accessions_mpxv.txt
+++ b/config/exclude_accessions_mpxv.txt
@@ -10,4 +10,4 @@ ON602722  # MPXV_FRA_2022_TLS67
 ON622721  #MPXV_1_IT_Milan_2022
 ON754989  #mpx_2022_Canada_AB2
 OP012849  #MPXV/human/Taiwan/110-364682/2022
-
+KJ642615  #Potential recombinant between clade 2 and 3


### PR DESCRIPTION
### Description of proposed changes
It appears as though clade 3 strain Nigeria 78 = KJ642615 is a recombinant of clade 2 and clade 3.

It causes the divergence of clade 3 to be much larger than it should be compared to clade 2. Removing this potential recombinant results in a more sensible tree.

Flagged by @rneher 