### PR TITLE
feat: mask more specifically

### DIFF
--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -32,6 +32,6 @@ root: "MK783032 MK783030"
 recency: true
 
 mask:
-  from_beginning: 1500
+  from_beginning: 800
   from_end: 6422
   maskfile: "config/mask.bed"

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -33,6 +33,6 @@ clock_std_dev: 6e-6
 recency: true
 
 mask:
-  from_beginning: 1500
+  from_beginning: 1350
   from_end: 6422
   maskfile: "config/mask_overview.bed"

--- a/config/mask.bed
+++ b/config/mask.bed
@@ -1,5 +1,10 @@
 Chrom	ChromStart	ChromEnd	locus tag	Comment
-chr	2300	2600		potential sequencing errors in CH sequence
-chr	6400	7500		very diverse region
 chr	133050	133250		indel variation and long homopolymers
-chr	173250	173460		indel variation and long repetitive elements
+chr	136500	136600		indel variation and long homopolymers
+chr	140050	140250		indel variation and long repetitive elements
+chr	146750	147000		indel variation and long repetitive elements
+chr	150500	150650		indel variation and long repetitive elements
+chr	169250	169500		indel variation and long repetitive elements
+chr	169700	169800		indel variation and long repetitive elements
+chr	173150	173350		indel variation and long repetitive elements
+chr	179000	179300		indel variation and long repetitive elements

--- a/config/mask_overview.bed
+++ b/config/mask_overview.bed
@@ -1,7 +1,16 @@
 Chrom	ChromStart	ChromEnd	locus tag	Comment
 chr	6400	7500		very diverse region
 chr	133050	133250		indel variation and long homopolymers
-chr	146830	146930		indel variation
+chr	136500	136600		indel variation and long homopolymers
+chr	140050	140250		indel variation and long repetitive elements
+chr	146750	147000		indel variation and long repetitive elements
+chr	148325	138375		indel variation and long homopolymers
+chr	150500	150650		indel variation and long repetitive elements
 chr	156000	159000		indel variation and long homopolymers
-chr	169700	169800		indel variation and long homopolymers
-chr	173200	173440		indel variation and long homopolymers
+chr	163100	163250		indel variation and long repetitive elements
+chr	169250	169500		indel variation and long repetitive elements
+chr	169700	169800		indel variation and long repetitive elements
+chr	173150	173350		indel variation and long repetitive elements
+chr	174500	174550		indel variation and long repetitive elements
+chr	179000	179300		indel variation and long repetitive elements
+chr	180400	180500		indel variation and long homopolymers


### PR DESCRIPTION
### Description of proposed changes

Sometimes it seems that IQtree splits branches into two based on clusters of Ns/not-Ns.

I carefully reviewed alignments and masked all tandem repeat and homopolymers stretches where a significant portion of sequences have Ns.

This should make trees more stable.

I tested builds for both hmpxv1 and mpxv with the new mask.

I think some of the previous masking was done against a different reference, hence some of our mask regions may have been shifted slightly. This is fixed now.