### PR TITLE
feat: add hmpxv1_big build with more sequences per group

### DIFF
--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -1,0 +1,46 @@
+name: Rebuild hmpxv1
+
+on:
+  repository_dispatch:
+    types:
+      - rebuild
+      - rebuild_hmpxv1-big
+
+  workflow_dispatch:
+
+jobs:
+  rebuild_mpxv:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_RUN_ID: ${{ github.run_id }}
+      SLACK_CHANNELS: monkeypox-updates
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: launch_build
+        run: |
+          ./bin/write-envdir env.d \
+            AWS_DEFAULT_REGION \
+            GITHUB_RUN_ID \
+            SLACK_TOKEN \
+            SLACK_CHANNELS
+
+          nextstrain build \
+            --aws-batch \
+            --detach \
+            --no-download \
+            --exec env \
+            . \
+              envdir env.d snakemake notify_on_deploy \
+                --configfiles config/config_hmpxv1_big.yaml config/nextstrain_automation.yaml \
+                --printshellcmds
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: notify_pipeline_failed
+        if: ${{ failure() }}
+        run: ./bin/notify-on-error

--- a/config/auspice_config_hmpxv1_big.json
+++ b/config/auspice_config_hmpxv1_big.json
@@ -1,0 +1,77 @@
+{
+  "title": "Genomic epidemiology of hMPXV-1 (clade IIb) monkeypox virus using as many sequences as possible",
+  "maintainers": [
+    {"name": "Nextstrain team", "url": "http://nextstrain.org"}
+  ],
+  "data_provenance": [
+    {
+      "name": "GenBank",
+      "url": "https://www.ncbi.nlm.nih.gov/genbank/"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/monkeypox",
+  "colorings": [
+    {
+      "key": "outbreak",
+      "title": "Outbreak",
+      "type": "categorical"
+    },
+    {
+      "key": "lineage",
+      "title": "Lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "GA_CT_fraction",
+      "title": "G→A or C→T fraction",
+      "type": "continuous"
+    },
+    {
+      "key": "dinuc_context_fraction",
+      "title": "NGA/TCN context of G→A/C→T mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Recency",
+      "type": "categorical"
+    },
+    {
+      "key": "date_submitted",
+      "title": "Release Date",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "country"
+  ],
+  "display_defaults": {
+    "color_by": "lineage",
+    "map_triplicate": true,
+    "distance_measure": "num_date",
+    "transmission_lines": false
+  },
+  "filters": [
+    "clade_membership",
+    "lineage",
+    "country",
+    "region",
+    "recency",
+    "host"
+  ]
+}

--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -25,6 +25,9 @@ filters: "--exclude-where outbreak!=hMPXV-1"
 max_indel: 10000
 seed_spacing: 1000
 
+## treefix
+fix_tree: false
+
 ## refine
 timetree: true
 root: "MK783032 MK783030"

--- a/config/config_hmpxv1_big.yaml
+++ b/config/config_hmpxv1_big.yaml
@@ -1,0 +1,40 @@
+exclude: "config/exclude_accessions_mpxv.txt"
+reference: "config/reference.fasta"
+genemap: "config/genemap.gff"
+genbank_reference: "config/reference.gb"
+colors: "config/colors_hmpxv1.tsv"
+clades: "config/clades.tsv"
+lat_longs: "config/lat_longs.tsv"
+auspice_config: "config/auspice_config_hmpxv1_big.json"
+description: "config/description.md"
+
+strain_id_field: "accession"
+display_strain_field: "strain_original"
+
+build_name: "hmpxv1_big"
+auspice_name: "monkeypox_hmpxv1_big"
+
+## filter
+min_date: 2017
+min_length: 10000
+sequences_per_group: 1000
+group_by: "year month country"
+filters: "--exclude-where outbreak!=hMPXV-1"
+
+## align
+max_indel: 10000
+seed_spacing: 1000
+
+## refine
+timetree: true
+root: "MK783032 MK783030"
+clock_rate: 5.7e-5
+clock_std_dev: 2e-5
+
+## recency
+recency: true
+
+mask:
+  from_beginning: 800
+  from_end: 6422
+  maskfile: "config/mask.bed"

--- a/config/config_hmpxv1_big.yaml
+++ b/config/config_hmpxv1_big.yaml
@@ -25,6 +25,9 @@ filters: "--exclude-where outbreak!=hMPXV-1"
 max_indel: 10000
 seed_spacing: 1000
 
+## treefix
+fix_tree: true
+
 ## refine
 timetree: true
 root: "MK783032 MK783030"

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -24,6 +24,9 @@ sequences_per_group: 50
 max_indel: 10000
 seed_spacing: 1000
 
+## treefix
+fix_tree: false
+
 ## refine
 timetree: false
 root: "min_dev"

--- a/scripts/fix_tree.py
+++ b/scripts/fix_tree.py
@@ -1,0 +1,42 @@
+from collections import defaultdict
+import argparse
+from treetime import TreeAnc
+from Bio import Phylo
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(
+        description="remove time info",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--alignment', type=str, required=True, help="input sequences")
+    parser.add_argument('--input-tree', type=str, required=True, help="input nwk")
+    parser.add_argument('--output', type=str, required=True, help="output nwk")
+    args = parser.parse_args()
+
+    T = Phylo.read(args.input_tree, 'newick')
+
+    T.root_at_midpoint()
+
+    tt = TreeAnc(tree=T, aln=args.alignment, gtr='JC69')
+    tt.optimize_tree(prune_short=True)
+
+    nodes_to_merge = defaultdict(list)
+    for n in T.get_nonterminals():
+        shared_mutations = defaultdict(list)
+        for c in n:
+            for mut in c.mutations:
+                if (mut[0] in 'ACGT') and (mut[2] in 'ACGT'):
+                    shared_mutations[mut].append(c)
+        for mut in shared_mutations:
+            if len(shared_mutations[mut])>1:
+                nodes_to_merge[(n,tuple(shared_mutations[mut]))].append(mut)
+
+    for parent, children in nodes_to_merge:
+        parent.clades = [c for c in parent if c not in children]
+        parent.clades.append(Phylo.BaseTree.Clade(
+                branch_length=tt.one_mutation))
+        parent.clades[-1].clades=list(children)
+        print("merging",children)
+
+    Phylo.write(T, args.output, 'newick')

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -147,6 +147,22 @@ rule tree:
             --nthreads {threads}
         """
 
+rule fix_tree:
+    message: "Building tree"
+    input:
+        tree = rules.tree.output.tree,
+        alignment = build_dir + "/{build_name}/masked.fasta"
+    output:
+        tree = build_dir + "/{build_name}/tree_fixed.nwk"
+    threads: 8
+    shell:
+        """
+        python3 scripts/fix_tree.py \
+            --alignment {input.alignment} \
+            --input-tree {input.tree} \
+            --output {output.tree}
+        """
+
 rule refine:
     message:
         """
@@ -157,7 +173,7 @@ rule refine:
           - filter tips more than {params.clock_filter_iqd} IQDs from clock expectation
         """
     input:
-        tree = rules.tree.output.tree,
+        tree = rules.fix_tree.output.tree,
         alignment = build_dir + "/{build_name}/masked.fasta",
         metadata = build_dir + "/{build_name}/metadata.tsv"
     output:

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -173,7 +173,7 @@ rule refine:
           - filter tips more than {params.clock_filter_iqd} IQDs from clock expectation
         """
     input:
-        tree = rules.fix_tree.output.tree,
+        tree = lambda w: rules.fix_tree.output.tree if config["fix_tree"] else rules.tree.output.tree,
         alignment = build_dir + "/{build_name}/masked.fasta",
         metadata = build_dir + "/{build_name}/metadata.tsv"
     output:
@@ -184,7 +184,7 @@ rule refine:
         date_inference = "marginal",
         clock_filter_iqd = 0,
         root = config["root"],
-        clock_rate = lambda w: f"--clock-rate {config['clock_rate']}" if "clock_rate" in config else "",
+        clock_rate = lambda w: "--clock-rate {config['clock_rate']}" if "clock_rate" in config else "",
         clock_std_dev = lambda w: f"--clock-std-dev {config['clock_std_dev']}" if "clock_std_dev" in config else ""
     shell:
         """

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -184,7 +184,7 @@ rule refine:
         date_inference = "marginal",
         clock_filter_iqd = 0,
         root = config["root"],
-        clock_rate = lambda w: "--clock-rate {config['clock_rate']}" if "clock_rate" in config else "",
+        clock_rate = lambda w: f"--clock-rate {config['clock_rate']}" if "clock_rate" in config else "",
         clock_std_dev = lambda w: f"--clock-std-dev {config['clock_std_dev']}" if "clock_std_dev" in config else ""
     shell:
         """


### PR DESCRIPTION
### Description of proposed changes

In order to increase representativeness of the builds, the current hMPXV-1 build limits sequences per month and country to 50. This means that some sequences from the US, Germany and Portugal do not show up.

For lineage designation purposes and to help researchers see all their sequences, this PR adds a build `hmpxv1_big` that has a higher limit for `month country` groups.

### Next steps

We may want to add this build to the ones triggered and deployed by ingest and to the GitHub actions.

This PR here just allows this build to be made via 

```bash
snakemake -j all -pr -F --configfile config/config_hmpxv1_big.yaml
```

### Testing

I tested this locally and it worked.