### PR TITLE
feat: add tree_exclude sites so that Colombian sequences don't need to be excluded

### DIFF
--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -7,6 +7,7 @@ clades: "config/clades.tsv"
 lat_longs: "config/lat_longs.tsv"
 auspice_config: "config/auspice_config_hmpxv1.json"
 description: "config/description.md"
+tree_mask: "config/tree_mask.tsv"
 
 strain_id_field: "accession"
 display_strain_field: "strain_original"

--- a/config/config_hmpxv1_big.yaml
+++ b/config/config_hmpxv1_big.yaml
@@ -7,6 +7,7 @@ clades: "config/clades.tsv"
 lat_longs: "config/lat_longs.tsv"
 auspice_config: "config/auspice_config_hmpxv1_big.json"
 description: "config/description.md"
+tree_mask: "config/tree_mask.tsv"
 
 strain_id_field: "accession"
 display_strain_field: "strain_original"

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -7,6 +7,7 @@ lat_longs: "config/lat_longs.tsv"
 auspice_config: "config/auspice_config_mpxv.json"
 description: "config/description.md"
 clades: "config/clades.tsv"
+tree_mask: "config/tree_mask.tsv"
 
 strain_id_field: "accession"
 display_strain_field: "strain_original"

--- a/config/exclude_accessions_mpxv.txt
+++ b/config/exclude_accessions_mpxv.txt
@@ -10,6 +10,4 @@ ON602722  # MPXV_FRA_2022_TLS67
 ON622721  #MPXV_1_IT_Milan_2022
 ON754989  #mpx_2022_Canada_AB2
 OP012849  #MPXV/human/Taiwan/110-364682/2022
-KJ642615  #Potential recombinant between clade 2 and 3
-OP295382  #Colombian B.1 with rev to ref
-OP295383  #Colombian B.1 with rev to ref
+KJ642615  #Potential recombinant between clade IIa and IIb

--- a/config/tree_mask.tsv
+++ b/config/tree_mask.tsv
@@ -1,0 +1,4 @@
+Reverted to ref in OP295382-3	1262
+Reverted to ref in OP295382-3	3111
+Reverted to ref in OP295382-3	3522
+Reverted to ref in OP295382-3	3818

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -145,6 +145,7 @@ rule tree:
         "Building tree"
     input:
         alignment=build_dir + "/{build_name}/masked.fasta",
+        tree_mask=config["tree_mask"],
     output:
         tree=build_dir + "/{build_name}/tree_raw.nwk",
     threads: 8
@@ -152,6 +153,7 @@ rule tree:
         """
         augur tree \
             --alignment {input.alignment} \
+            --exclude-sites {input.tree_mask} \
             --output {output.tree} \
             --nthreads {threads}
         """


### PR DESCRIPTION
### Description of proposed changes
There are 2 Colombian sequences with 4 reversions to A.1.

These mess up tree topology. So we've excluded them for now.

A better way is to mask these 4 sites (they are in ITR so not surprising there can be issues there) for tree build only (soft mask). That way the tree topology is correct but the sequences show still on the tree.

Test run here: should appear on staging in 30-45 min  for checking
https://github.com/nextstrain/monkeypox/actions/runs/3007463882
