### PR TITLE
dev: Remove vestigial override of Docker image in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,6 @@ on:
 jobs:
   pathogen-ci:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
-    with:
-      env: |
-        NEXTSTRAIN_DOCKER_IMAGE: nextstrain/base
 
   lint:
      runs-on: ubuntu-latest


### PR DESCRIPTION
Left over from early days of this repo when we needed a non-default image.  We reverted to the default image, nextstrain/base, not long after in "feat: rename nextalign -> nextalign2 to work with base image" (9176b3c), which left this small bit of unnecessary config.

### Testing
- [x] CI passes