### PR TITLE
Cap the tree rule's threads to whatever was given to the workflow

### DIFF
--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -189,6 +189,7 @@ rule tree:
         tree_mask=config["tree_mask"],
     output:
         tree=build_dir + "/{build_name}/tree_raw.nwk",
+    threads: workflow.cores
     shell:
         """
         augur tree \
@@ -196,7 +197,7 @@ rule tree:
             --exclude-sites {input.tree_mask} \
             --tree-builder-args="-redo" \
             --output {output.tree} \
-            --nthreads auto
+            --nthreads {threads}
         """
 
 


### PR DESCRIPTION
This solves two issues:

 1. It informs Snakemake's scheduler about the number of threads this rule will use.  Previously, the rule would use as many as possible but Snakemake's scheduler would think it was only using 1, potentially leading the scheduler could oversubscribe the system. This was likely only a latent issue given the current serial nature of the workflow.

 2. It prevents Augur's CPU detection from seeing all the host CPUs even when it's running inside a CPU-time limited container context.  See also <https://github.com/nextstrain/augur/issues/1058>.

When I briefly audited the rest of the workflow for implicit threads usage, I noted that this same pattern is already used by the align rule.

