### PR TITLE
ingest: Pull submitting organization from NCBI

### DIFF
--- a/.github/workflows/fetch-and-ingest-branch.yaml
+++ b/.github/workflows/fetch-and-ingest-branch.yaml
@@ -34,7 +34,7 @@ jobs:
           ingest \
             envdir env.d snakemake \
               --configfiles config/config.yaml config/optional-branch.yaml \
-              --config trigger_rebuild=false \
+              --config trigger_rebuild=False \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/ingest/bin/genbank-url
+++ b/ingest/bin/genbank-url
@@ -46,6 +46,7 @@ params = {
             ('sra_accession',           'SRALink_csv'),
             ('title',                   'Definition_s'),
             ('authors',                 'Authors_csv'),
+            ('submitting_organization', 'SubmitterAffilFull_s'),
             ('publications',            'PubMed_csv'),
             ('sequence',                'Nucleotide_seq'),
         ]

--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -6,7 +6,7 @@ transform:
   # Fields to rename.
   # This is the first step in the pipeline, so any references to field names
   # in the configs below should use the new field names
-  field_map: ['collected=date', 'submitted=date_submitted', 'genbank_accession=accession']
+  field_map: ['collected=date', 'submitted=date_submitted', 'genbank_accession=accession', 'submitting_organization=institution']
   # Standardized strain name regex
   # Currently accepts any characters because we do not have a clear standard for strain names
   strain_regex: '^.+$'


### PR DESCRIPTION
### Description of proposed changes

Pull in the new field that NCBI Virus added for the submitters' affiliated organization.

Currently pulling this in as `submitting_organization` to be clear that this is the submitters' organization in our raw NDJSON. Then our ingest pipeline renames this field to `institution` to match existing curated annotations.¹

¹ https://github.com/nextstrain/monkeypox/pull/43

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test run on branch ([GH Action](https://github.com/nextstrain/monkeypox/actions/runs/3300499546) | [AWS Batch](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/6f57a7e3-3e66-486d-9490-c6838c2eb1c9))

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
