### PR TITLE
Update PAT_GITHUB_DISPATCH secret

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -60,7 +60,7 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        PAT_GITHUB_DISPATCH: ${{ secrets.PAT_GITHUB_DISPATCH }}
+        PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
 
     - name: notify_pipeline_failed
       if: ${{ failure() }}

--- a/.github/workflows/rebuild-all.yaml
+++ b/.github/workflows/rebuild-all.yaml
@@ -6,13 +6,12 @@ on:
 jobs:
   rebuild_all:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_RUN_ID: ${{ github.run_id }}
-      SLACK_CHANNELS: monkeypox-updates
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
+      - uses: actions/checkout@v3
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
-          event-type: rebuild
+        run: ./ingest/bin/trigger monkeypox rebuild
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          SLACK_CHANNELS: monkeypox-updates
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}

--- a/.github/workflows/rebuild-all.yaml
+++ b/.github/workflows/rebuild-all.yaml
@@ -11,7 +11,4 @@ jobs:
       - name: Repository Dispatch
         run: ./ingest/bin/trigger monkeypox rebuild
         env:
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          SLACK_CHANNELS: monkeypox-updates
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}

--- a/.github/workflows/rebuild-all.yaml
+++ b/.github/workflows/rebuild-all.yaml
@@ -14,5 +14,5 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.PAT_GITHUB_DISPATCH }}
+          token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
           event-type: rebuild


### PR DESCRIPTION
Use the shared organization secret for the dispatch token so it no longer has to be managed as a separate repo secret.

I've already added the org secret `GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH` to this repo.

