### PR TITLE
fix: Use first field instead of last field

### DIFF
--- a/ingest/bin/transform-strain-names
+++ b/ingest/bin/transform-strain-names
@@ -40,6 +40,7 @@ if __name__ == '__main__':
                 for field in args.backup_fields:
                     if record.get(field):
                         record['strain'] = str(record[field])
+                        break
 
         if record['strain'] == '':
             print(f"WARNING: Record number {index} has an empty string as the strain name.", file=stderr)


### PR DESCRIPTION
### Description of proposed changes



Assuming the documentation in transform strain names is the goal

> If multiple fields are provided, will use the first field that has a non-empty string.

Need a `break` in the for loop, otherwise "last field" will be used.

Ran across this because I was exploring a ncbi datasets genbank.ndjson file:

```
cat genbank.ndjson  \
  | ./bin/transform-strain-names  \
    --strain-regex ^.+$  \
    --backup-fields "Isolate Lineage" "Accession" "accession" \
  > genbank_transform_strain_name.ndson
```


### Related issue(s)
 
### Testing

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
