### PR TITLE
Add submission recency categories for older than 1 month

### DIFF
--- a/config/color_ordering.tsv
+++ b/config/color_ordering.tsv
@@ -16871,8 +16871,11 @@ region	North America
 
 ################
 
-
-recency	Older
+recency	Older than 15 years
+recency	3-15 years ago
+recency	1-3 years ago
+recency	3-12 months ago
+recency	1-3 months ago
 recency	One month ago
 recency	One week ago
 recency	3-7 days ago

--- a/scripts/construct-recency-from-submission-date.py
+++ b/scripts/construct-recency-from-submission-date.py
@@ -20,8 +20,16 @@ def get_recency(date_str, ref_date):
         return 'One week ago'
     elif delta_days<31:
         return 'One month ago'
+    elif delta_days < 121:
+        return '1-3 months ago'
+    elif delta_days < 365:
+        return '3-12 months ago'
+    elif delta_days < 365*4:
+        return '1-3 years ago'
+    elif delta_days < 365*16:
+        return '3-15 years ago'
     elif delta_days>=31:
-        return 'Older'
+        return 'Older than 15 years'
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Right now, almost everything shows up as "Older" which isn't particularly useful.

I'm sometimes interested whether sequences were uploaded 4 months ago or 4 years ago. The new categories fill that gap.

### Testing

Looks good in CI test build