### PR TITLE
fix: Add `--cores all` to rebuild-mpxv.yaml

### DIFF
--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -35,6 +35,7 @@ jobs:
           . \
             envdir env.d snakemake notify_on_deploy \
               --configfiles config/config_mpxv.yaml config/nextstrain_automation.yaml \
+              --cores all \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
This is required for the action to be compatible with snakemake version >5.11.0
which started to require the `--cores` option

For more context see:
- https://github.com/nextstrain/cli/issues/272 
- https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1681324279363569?thread_ts=1681293140.124269&cid=C01LCTT7JNN

- [ ] Checks pass

I added `--cores all` because we don't limit number of cores to use in the call of `nextstrain build`
