### PR TITLE
Snakefile: Set AUGUR_RECURSION_LIMIT=10000

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -8,6 +8,13 @@ if version.parse(augur_version) < version.parse(min_version):
     print(f"Current augur version: {augur_version}. Minimum required: {min_version}")
     sys.exit(1)
 
+# Set the maximum recursion limit globally for all shell commands, to avoid
+# issues with large trees crashing the workflow.  Preserve Snakemake's default
+# use of Bash's "strict mode", as we rely on that behaviour.
+# Copied directly from the ncov workflow
+# https://github.com/nextstrain/ncov/blob/c6fcdf6b19f9dcb92c9f59d0fda1c953192e3950/Snakefile#L15-L18
+shell.prefix("set -euo pipefail; export AUGUR_RECURSION_LIMIT=10000; ")
+
 if not config:
 
     configfile: "config/config_hmpxv1.yaml"


### PR DESCRIPTION
### Description of proposed changes

This change is a response to the recursion error that a user ran into when running the workflow with a large number of sequences during Nextstrain office hours on 2023-04-13.

Set the recursion limit globally instead of asking the user to remember to set the environment variable or edit their own Snakefile.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
