### PR TITLE
Connect the output sequence parameter

### DIFF
--- a/ingest/workflow/snakemake_rules/transform.smk
+++ b/ingest/workflow/snakemake_rules/transform.smk
@@ -91,6 +91,7 @@ rule transform:
             | ./bin/ndjson-to-tsv-and-fasta \
                 --metadata-columns {params.metadata_columns} \
                 --metadata {output.metadata} \
+                --fasta {output.sequences} \
                 --id-field {params.id_field} \
                 --sequence-field {params.sequence_field} ) 2>> {log}
         """


### PR DESCRIPTION
### Description of proposed changes

This bug was invisible before because when the flag `--sequence` is left out, a default "sequences.fasta" file is generated which happens to match the `output.sequences` parameter. When modifying  the `output.sequences` to a different filename, the pipeline would fail.

This bug surfaced while writing the dengue ingest where output.sequence needed to be parameterized across serotypes (e.g. "sequences_denv1.fasta", "sequences_denv2.fasta"). 

### Related issue(s)

### Testing

- [ ] Checks pass
