### PR TITLE
ingest: retry genbank downloads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2,10 +2,12 @@ from packaging import version
 from augur.__version__ import __version__ as augur_version
 import sys
 
-min_version = "16.0.0"
-if version.parse(augur_version) < version.parse(min_version):
+min_augur_version = "16.0.0"
+if version.parse(augur_version) < version.parse(min_augur_version):
     print("This pipeline needs a newer version of augur than you currently have...")
-    print(f"Current augur version: {augur_version}. Minimum required: {min_version}")
+    print(
+        f"Current augur version: {augur_version}. Minimum required: {min_augur_version}"
+    )
     sys.exit(1)
 
 # Set the maximum recursion limit globally for all shell commands, to avoid

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -1,3 +1,9 @@
+from snakemake.utils import min_version
+
+min_version(
+    "7.7.0"
+)  # Snakemake 7.7.0 introduced `retries` directive used in fetch-sequences
+
 if not config:
 
     configfile: "config/config.yaml"

--- a/ingest/workflow/snakemake_rules/fetch_sequences.smk
+++ b/ingest/workflow/snakemake_rules/fetch_sequences.smk
@@ -17,6 +17,7 @@ Produces final output as
 rule fetch_from_genbank:
     output:
         genbank_ndjson="data/genbank.ndjson",
+    retries: 5  # Requires snakemake 7.7.0 or later
     shell:
         """
         ./bin/fetch-from-genbank 10244 > {output.genbank_ndjson}


### PR DESCRIPTION
- refactor(build): min_version to min_augur_version
- feat(ingest): retry download, min smk version now 7.7.0
