### PR TITLE
fix: snakemake warning on geolocation filepath

### DIFF
--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -39,7 +39,7 @@ transform:
   geolocation_rules_url: 'https://raw.githubusercontent.com/nextstrain/ncov-ingest/master/source-data/gisaid_geoLocationRules.tsv'
   # Local geolocation rules that are only applicable to monkeypox data
   # Local rules can overwrite the general geolocation rules provided above
-  local_geolocation_rules: './source-data/geolocation-rules.tsv'
+  local_geolocation_rules: 'source-data/geolocation-rules.tsv'
   # User annotations file
   annotations: './source-data/annotations.tsv'
   # ID field used to merge annotations


### PR DESCRIPTION
### Description of proposed changes

This path when used as an input causes Snakemake to produce a warning (emitted at the beginning of the logs) and mentioned here: https://github.com/nextstrain/dengue/pull/6#discussion_r1149887926

> Relative file path './source-data/geolocation-rules.tsv' starts with './'.
This is redundant and strongly discouraged. It can also lead to inconsistent results of the file-matching approach used by Snakemake. You can simply omit the './' for relative file paths.

This commit removes the `./` from the filepath to avoid the warning.

### Related issue(s)

* https://github.com/nextstrain/dengue/pull/6#discussion_r1149887926

### Testing

- [ ] Checks pass

