### PR TITLE
Allow specification of image in workflows

### DIFF
--- a/.github/workflows/fetch-and-ingest-branch.yaml
+++ b/.github/workflows/fetch-and-ingest-branch.yaml
@@ -3,6 +3,13 @@ name: Fetch and ingest (on branch)
 on:
   # Manually triggered using GitHub's UI
   workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for build (will override the default of "nextstrain build")'
+        required: false
+
+env:
+  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
 
 jobs:
   fetch-and-ingest:
@@ -10,6 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      with:
+        python-version: "3.10"
 
     - name: install-pyyaml
       run: python3 -m pip install pyyaml

--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -26,6 +26,13 @@ on:
 
   # Manually triggered using GitHub's UI
   workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for build (will override the default of "nextstrain build")'
+        required: false
+
+env:
+  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
 
 jobs:
   fetch-and-ingest:
@@ -37,6 +44,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      with:
+        python-version: "3.10"
 
     - name: run_pipeline
       run: |

--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -7,6 +7,13 @@ on:
       - rebuild_hmpxv1-big
 
   workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for build (will override the default of "nextstrain build")'
+        required: false
+
+env:
+  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
 
 jobs:
   rebuild_hmpxv1_big:
@@ -18,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+        with:
+          python-version: "3.10"
 
       - name: launch_build
         run: |

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -7,6 +7,13 @@ on:
       - rebuild_hmpxv1
 
   workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for build (will override the default of "nextstrain build")'
+        required: false
+
+env:
+  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
 
 jobs:
   rebuild_hmpxv1:
@@ -18,6 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      with:
+        python-version: "3.10"
 
     - name: launch_build
       run: |

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -7,6 +7,13 @@ on:
       - rebuild_mpxv
 
   workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for build (will override the default of "nextstrain build")'
+        required: false
+
+env:
+  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
 
 jobs:
   rebuild_mpxv:
@@ -18,6 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      with:
+        python-version: "3.10"
 
     - name: launch_build
       run: |


### PR DESCRIPTION
Useful for testing compatibility of docker images with existing workflows

Test run worked, with a non-default tag of docker-base as intended
```
$ gh workflow run -r allow-image-specification-in-actions
? Select a workflow Rebuild mpxv (rebuild-mpxv.yaml)
? image nextstrain/base:branch-version-updates
✓ Created workflow_dispatch event for rebuild-mpxv.yaml at allow-image-specification-in-actions
```