### PR TITLE
fix: annotations is a file not a param

### DIFF
--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -41,7 +41,7 @@ transform:
   # Local rules can overwrite the general geolocation rules provided above
   local_geolocation_rules: 'source-data/geolocation-rules.tsv'
   # User annotations file
-  annotations: './source-data/annotations.tsv'
+  annotations: 'source-data/annotations.tsv'
   # ID field used to merge annotations
   annotations_id: 'accession'
   # Field to use as the sequence ID in the FASTA file

--- a/ingest/workflow/snakemake_rules/transform.smk
+++ b/ingest/workflow/snakemake_rules/transform.smk
@@ -40,6 +40,7 @@ rule transform:
     input:
         sequences_ndjson="data/sequences.ndjson",
         all_geolocation_rules="data/all-geolocation-rules.tsv",
+        annotations=config["transform"]["annotations"],
     output:
         metadata="data/metadata_raw.tsv",
         sequences="data/sequences.fasta",
@@ -57,7 +58,6 @@ rule transform:
         authors_field=config["transform"]["authors_field"],
         authors_default_value=config["transform"]["authors_default_value"],
         abbr_authors_field=config["transform"]["abbr_authors_field"],
-        annotations=config["transform"]["annotations"],
         annotations_id=config["transform"]["annotations_id"],
         metadata_columns=config["transform"]["metadata_columns"],
         id_field=config["transform"]["id_field"],
@@ -86,7 +86,7 @@ rule transform:
             | ./bin/apply-geolocation-rules \
                 --geolocation-rules {input.all_geolocation_rules} \
             | ./bin/merge-user-metadata \
-                --annotations {params.annotations} \
+                --annotations {input.annotations} \
                 --id-field {params.annotations_id} \
             | ./bin/ndjson-to-tsv-and-fasta \
                 --metadata-columns {params.metadata_columns} \


### PR DESCRIPTION
### Description of proposed changes

I was wondering why the dot was needed in 

```
  annotations: './source-data/annotations.tsv'
```

and not in 

```
  local_geolocation_rules: 'source-data/geolocation-rules.tsv'
```

The answer is that 'local_geolocation_rules" were marked as [input files in the snakemake rule](https://github.com/nextstrain/monkeypox/blob/46fc9acc0eadb6fe9e7c8db77245f8e4d857a224/ingest/workflow/snakemake_rules/transform.smk#L30). 

This change marks the annotation as an input file, basically the real fix of the warning mentioned in  https://github.com/nextstrain/monkeypox/pull/153 

### Related issue(s)

### Testing

- [ ] Checks pass

