### PR TITLE
Update monkeypox to mpx or mpxv in text areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nextstrain.org/monkeypox
 
-This is the [Nextstrain](https://nextstrain.org) build for monkeypox virus. Output from this build is visible at [nextstrain.org/monkeypox](https://nextstrain.org/monkeypox).
-The lineages within the recent monkeypox outbreaks in humans are defined in a separate [lineage-designation repository](https://github.com/mpxv-lineages/lineage-designation).
+This is the [Nextstrain](https://nextstrain.org) build for MPXV (monkeypox virus). Output from this build is visible at [nextstrain.org/monkeypox](https://nextstrain.org/monkeypox).
+The lineages within the recent mpox outbreaks in humans are defined in a separate [lineage-designation repository](https://github.com/mpxv-lineages/lineage-designation).
 
 ## Usage
 

--- a/config/auspice_config_hmpxv1.json
+++ b/config/auspice_config_hmpxv1.json
@@ -1,5 +1,5 @@
 {
-  "title": "Genomic epidemiology of monkeypox virus",
+  "title": "Genomic epidemiology of MPXV",
   "maintainers": [
     {"name": "Nextstrain team", "url": "http://nextstrain.org"}
   ],

--- a/config/auspice_config_hmpxv1_big.json
+++ b/config/auspice_config_hmpxv1_big.json
@@ -1,5 +1,5 @@
 {
-  "title": "Genomic epidemiology of hMPXV-1 (clade IIb) monkeypox virus using as many sequences as possible",
+  "title": "Genomic epidemiology of hMPXV-1 (clade IIb) MPXV using as many sequences as possible",
   "maintainers": [
     {"name": "Nextstrain team", "url": "http://nextstrain.org"}
   ],

--- a/config/auspice_config_mpxv.json
+++ b/config/auspice_config_mpxv.json
@@ -1,5 +1,5 @@
 {
-  "title": "Genomic epidemiology of monkeypox virus",
+  "title": "Genomic epidemiology of MPXV",
   "maintainers": [
     {"name": "Nextstrain team", "url": "http://nextstrain.org"}
   ],

--- a/config/description.md
+++ b/config/description.md
@@ -1,6 +1,6 @@
 We gratefully acknowledge the authors, originating and submitting laboratories of the genetic sequences and metadata for sharing their work. Please note that although data generators have generously shared data in an open fashion, that does not mean there should be free license to publish on this data. Data generators should be cited where possible and collaborations should be sought in some circumstances. Please try to avoid scooping someone else's work. Reach out if uncertain.
 
-We maintain two views of monkeypox virus evolution:
+We maintain two views of MPXV evolution:
 
 The first is [`monkeypox/hmpxv1`](https://nextstrain.org/monkeypox/hmpxv1), which focuses on recent viruses transmitting from human-to-human and includes viruses belonging to the hMPXV1 clade as denoted by [Happi et al](https://virological.org/t/urgent-need-for-a-non-discriminatory-and-non-stigmatizing-nomenclature-for-monkeypox-virus/853). Here, we conduct a molecular clock analysis in which evolutionary rate is estimated from the data (with a resulting estimate of ~6 &times; 10<sup>-5</sup> subs per site per year).
 


### PR DESCRIPTION
### Description of proposed changes

Modifies the config, description, and README files to replace "monkeypox" with either "mpox" (when referring to cases) or "MPXV" when referring to the virus.

Though the virus is still called "monkeypox virus", recommendations around both stigma and accuracy (monkeys are not the main reservoir) have suggested moving away from using 'monkey' in the name.

Changing the build and URLs would require a much larger push and many redirects, and needs to be considered and discussed further.
