### PR TITLE
Snakefile: remove AUGUR_RECURSION_LIMIT

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -10,12 +10,6 @@ if version.parse(augur_version) < version.parse(min_augur_version):
     )
     sys.exit(1)
 
-# Set the maximum recursion limit globally for all shell commands, to avoid
-# issues with large trees crashing the workflow.  Preserve Snakemake's default
-# use of Bash's "strict mode", as we rely on that behaviour.
-# Copied directly from the ncov workflow
-# https://github.com/nextstrain/ncov/blob/c6fcdf6b19f9dcb92c9f59d0fda1c953192e3950/Snakefile#L15-L18
-shell.prefix("set -euo pipefail; export AUGUR_RECURSION_LIMIT=10000; ")
 
 if not config:
 


### PR DESCRIPTION
The AUGUR_RECURSION_LIMIT is set to 10,000 by default since Augur 22.0.0 and the workflow's minimum required Augur version is now 22.2.0¹

¹ https://github.com/nextstrain/monkeypox/blob/5216a13c407d0e842b40951907c49de6fc6b967a/Snakefile#L5

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
