### PR TITLE
Reorganize config and rules around filter/subsampling

### DIFF
--- a/config/config_hmpxv1.yaml
+++ b/config/config_hmpxv1.yaml
@@ -1,4 +1,3 @@
-exclude: "config/exclude_accessions_mpxv.txt"
 reference: "config/reference.fasta"
 genemap: "config/genemap.gff"
 genbank_reference: "config/reference.gb"
@@ -17,14 +16,15 @@ display_strain_field: "strain"
 build_name: "hmpxv1"
 auspice_name: "mpox_clade-IIb"
 
-## filter
-min_date: 2017
-min_length: 100000
+filter:
+  exclude: "config/exclude_accessions_mpxv.txt"
+  min_date: 2017
+  min_length: 100000
 
 
 ### Set 1: Non-B.1 sequences: use all
 ### Set 2: B.1 sequences: small sample across year/country, maybe month
-filter:
+subsample:
   non_b1:
     group_by: "--group-by lineage year country"
     sequences_per_group: "--sequences-per-group 50"

--- a/config/config_hmpxv1_big.yaml
+++ b/config/config_hmpxv1_big.yaml
@@ -1,4 +1,3 @@
-exclude: "config/exclude_accessions_mpxv.txt"
 reference: "config/reference.fasta"
 genemap: "config/genemap.gff"
 genbank_reference: "config/reference.gb"
@@ -17,10 +16,12 @@ display_strain_field: "strain"
 build_name: "hmpxv1_big"
 auspice_name: "mpox_lineage-B.1"
 
-## filter
-min_date: 2022
-min_length: 180000
 filter:
+  exclude: "config/exclude_accessions_mpxv.txt"
+  min_date: 2022
+  min_length: 180000
+
+subsample:
   b1:
     group_by: "--group-by year month country"
     sequences_per_group: "--subsample-max-sequences 5000"

--- a/config/config_mpxv.yaml
+++ b/config/config_mpxv.yaml
@@ -1,4 +1,3 @@
-exclude: "config/exclude_accessions_mpxv.txt"
 reference: "config/reference.fasta"
 genemap: "config/genemap.gff"
 genbank_reference: "config/reference.gb"
@@ -17,13 +16,14 @@ display_strain_field: "strain"
 build_name: "mpxv"
 auspice_name: "mpox_all-clades"
 
-## filter
-min_date: 1950
-min_length: 100000
+filter:
+  exclude: "config/exclude_accessions_mpxv.txt"
+  min_date: 1950
+  min_length: 100000
 
 ### Set 1: Non-B.1 sequences: use all
 ### Set 2: B.1 sequences: small sample across year/country, maybe month
-filter:
+subsample:
   non_b1:
     group_by: "--group-by clade year country"
     sequences_per_group: "--sequences-per-group 50"

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -47,7 +47,6 @@ rule filter:
 
 rule subsample:
     input:
-        sequences=rules.filter.output.sequences,
         metadata=rules.filter.output.metadata,
     output:
         strains=build_dir + "/{build_name}/{sample}_strains.txt",
@@ -65,7 +64,6 @@ rule subsample:
     shell:
         """
         augur filter \
-            --sequences {input.sequences} \
             --metadata {input.metadata} \
             --metadata-id-columns {params.strain_id} \
             --output-strains {output.strains} \

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -15,11 +15,7 @@ In addition, `build_dir` and `auspice_dir` need to be defined upstream.
 
 rule exclude_bad:
     """
-    Removing strains that violate one of
-        - from {params.min_date} onwards
-        - excluding strains in {input.exclude}
-        - minimum genome length of {params.min_length}
-        - QC_rare_mutations == bad
+    Removing strains that do not satisfy certain requirements.
     """
     input:
         sequences="data/sequences.fasta",


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Subsampling is a form of filtering, but there is a conceptual distinction that is apparent in the rules and configs used in the ncov workflow, which I've mirrored here.

Put all filtering-related rules in a "filter" config, which configures a rule with the same name.

Put all subsampling-related rules in a "subsampling" config which also configures a rule with the same name.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Follow-up to #171

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
