### PR TITLE
Use pathogen-repo-build workflow for builds

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -31,27 +31,20 @@ on:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'
         required: false
 
-env:
-  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
-
 jobs:
   fetch-and-ingest:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_RUN_ID: ${{ github.run_id }}
-      SLACK_CHANNELS: monkeypox-updates
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        cli-version: ">=7.1.0"
-        python-version: "3.10"
-
-    - name: run_pipeline
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        SLACK_CHANNELS: monkeypox-updates
       run: |
         nextstrain build \
-          --aws-batch \
           --detach \
           --no-download \
           --cpus 32 \
@@ -62,15 +55,6 @@ jobs:
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \
-          --env PAT_GITHUB_DISPATCH \
+          --env PAT_GITHUB_DISPATCH="$GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH" \
           ingest \
             --configfiles config/config.yaml config/optional.yaml
-      env:
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
-
-    - name: notify_pipeline_failed
-      if: ${{ failure() }}
-      run: ./ingest/vendored/notify-on-job-fail Ingest nextstrain/monkeypox

--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -21,22 +21,18 @@ env:
 
 jobs:
   rebuild_hmpxv1_big:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_RUN_ID: ${{ github.run_id }}
-      SLACK_CHANNELS: monkeypox-updates
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-        with:
-          cli-version: ">=7.1.0"
-          python-version: "3.10"
-
-      - name: launch_build
-        run: |
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        SLACK_CHANNELS: monkeypox-updates
+      run: |
           nextstrain build \
-            --aws-batch \
             --detach \
             --no-download \
             --cpus 8 \
@@ -51,11 +47,3 @@ jobs:
               notify_on_deploy \
                 --configfiles config/config_hmpxv1_big.yaml config/nextstrain_automation.yaml \
                 --config auspice_prefix=$TRIAL_NAME
-        env:
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: notify_pipeline_failed
-        if: ${{ failure() }}
-        run: ./bin/notify-on-error

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -21,22 +21,18 @@ env:
 
 jobs:
   rebuild_hmpxv1:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_RUN_ID: ${{ github.run_id }}
-      SLACK_CHANNELS: monkeypox-updates
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        cli-version: ">=7.1.0"
-        python-version: "3.10"
-
-    - name: launch_build
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        SLACK_CHANNELS: monkeypox-updates
       run: |
         nextstrain build \
-          --aws-batch \
           --detach \
           --no-download \
           --cpus 8 \
@@ -51,11 +47,3 @@ jobs:
             notify_on_deploy \
               --configfiles config/config_hmpxv1.yaml config/nextstrain_automation.yaml \
               --config auspice_prefix=$TRIAL_NAME
-      env:
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-    - name: notify_pipeline_failed
-      if: ${{ failure() }}
-      run: ./bin/notify-on-error

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -21,22 +21,18 @@ env:
 
 jobs:
   rebuild_mpxv:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_RUN_ID: ${{ github.run_id }}
-      SLACK_CHANNELS: monkeypox-updates
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        cli-version: ">=7.1.0"
-        python-version: "3.10"
-
-    - name: launch_build
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        SLACK_CHANNELS: monkeypox-updates
       run: |
         nextstrain build \
-          --aws-batch \
           --detach \
           --no-download \
           --cpus 8 \
@@ -51,12 +47,3 @@ jobs:
             notify_on_deploy \
               --configfiles config/config_mpxv.yaml config/nextstrain_automation.yaml \
               --config auspice_prefix=$TRIAL_NAME
-      env:
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-    - name: notify_pipeline_failed
-      if: ${{ failure() }}
-      run: ./bin/notify-on-error
-


### PR DESCRIPTION
_Original commit is from @joverlee521, I just rebased it on master_

Simplify build workflows by using the reusable Nextstrain pathogen-repo-build workflow.

This does not update the fetch-and-ingest-branch workflow since that will require additional changes to support the custom configs.

This does remove the `notify_pipeline_failed` step in the workflows. They can be added as a separate job in the workflow if we think they are still helpful.
