### PR TITLE
Add pre-commit to CI lint action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,12 +12,13 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
 
   lint:
-     runs-on: ubuntu-latest
-     steps:
-     - uses: actions/checkout@v3
-     - uses: actions/setup-python@v4
-       with:
-         python-version: ~3
-     - run: pip install snakefmt
-     - run: snakefmt --check --compact-diff .
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ~3
+      - run: pip install snakefmt
+      - run: snakefmt --check --compact-diff .
+      - uses: pre-commit/action@v3.0.0
 


### PR DESCRIPTION
CI errors with

```
[Error: .github#L1](https://github.com/nextstrain/monkeypox/commit/8d0c898f30d9e6f99ae682edb5b544763af2bbbd#annotation_14383331521)
pre-commit/action@v3.0.0 is not allowed to be used in nextstrain/monkeypox. Actions in this workflow must be: within a repository owned by nextstrain, created by GitHub, or matching the following: aws-actions/configure-aws-credentials@*, codecov/codecov-action@*, conda-incubator/setup-miniconda@*, docker/build-push-action@*, docker/login-action@*, docker/setup-buildx-action@*, mamba-org/provision-with-micromamba@*, peter-evans/create-pull-request@v3, stefanzweifel/git-auto-commit-action@v4, docker/setup-qemu-action@*, dependabot/fetch-metadata@*, mamba-org/setup-micromamba@*, ruby/setup-ruby@v1.
```

Do you think it's worth adding precommit to the list of approved actions @victorlin?