### PR TITLE
chore: builds are robust now, can deploy straight to nextstrain-data

### DIFF
--- a/phylogenetic/config/nextstrain_automation.yaml
+++ b/phylogenetic/config/nextstrain_automation.yaml
@@ -2,4 +2,4 @@
 # Intended to be used internally by the Nextstrain team
 
 # deploy
-deploy_url: "s3://nextstrain-staging"
+deploy_url: "s3://nextstrain-data"


### PR DESCRIPTION
Builds are robust now by filtering out overdiverged strains
We can deploy straight to nextstrain-data reducing delay for new sequences to appear
In case of outliers, we can always fix and rebuild

Only reason we deployed to staging first was that a year ago, builds usually had issues.

I'll check regularly for issues.

See also: https://bedfordlab.slack.com/archives/C03G8HQEV18/p1695669299810249
