### PR TITLE
fix: correct vendored path in notify-on-* scripts after move and build action args

### DIFF
--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -47,4 +47,4 @@ jobs:
           . \
             notify_on_deploy \
               --configfiles $BUILD_DIR/config/mpxv/config.yaml $BUILD_DIR/config/nextstrain_automation.yaml \
-              --config auspice_prefix=$TRIAL_NAME --directory $BUILD_DIR
+              --config auspice_prefix=$TRIAL_NAME --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -31,6 +31,7 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         SLACK_CHANNELS: monkeypox-updates
+        BUILD_DIR: phylogenetic
       run: |
         nextstrain build \
           --detach \
@@ -43,7 +44,7 @@ jobs:
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \
-          phylogenetic \
+          . \
             notify_on_deploy \
-              --configfiles config/mpxv/config.yaml config/nextstrain_automation.yaml \
-              --config auspice_prefix=$TRIAL_NAME
+              --configfiles $BUILD_DIR/config/mpxv/config.yaml $BUILD_DIR/config/nextstrain_automation.yaml \
+              --config auspice_prefix=$TRIAL_NAME --directory $BUILD_DIR

--- a/phylogenetic/bin/notify-on-deploy
+++ b/phylogenetic/bin/notify-on-deploy
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
 : "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
 
-base="$(realpath "$(dirname "$0")/..")"
+base="$(realpath "$(dirname "$0")/../..")"
 ingest_vendored="$base/ingest/vendored"
 
 deployment_url="${1:?A deployment url is required as the first argument.}"

--- a/phylogenetic/bin/notify-on-error
+++ b/phylogenetic/bin/notify-on-error
@@ -7,7 +7,7 @@ set -euo pipefail
 : "${AWS_BATCH_JOB_ID:=}"
 : "${GITHUB_RUN_ID:=}"
 
-base="$(realpath "$(dirname "$0")/..")"
+base="$(realpath "$(dirname "$0")/../..")"
 ingest_vendored="$base/ingest/vendored"
 
 slack_ts_file="${1:-}"

--- a/phylogenetic/bin/notify-on-start
+++ b/phylogenetic/bin/notify-on-start
@@ -7,7 +7,7 @@ set -euo pipefail
 : "${AWS_BATCH_JOB_ID:=}"
 : "${GITHUB_RUN_ID:=}"
 
-base="$(realpath "$(dirname "$0")/..")"
+base="$(realpath "$(dirname "$0")/../..")"
 ingest_vendored="$base/ingest/vendored"
 
 build_name="${1:?A build name is required as the first argument.}"

--- a/phylogenetic/bin/notify-on-success
+++ b/phylogenetic/bin/notify-on-success
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
 : "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
 
-base="$(realpath "$(dirname "$0")/..")"
+base="$(realpath "$(dirname "$0")/../..")"
 ingest_vendored="$base/ingest/vendored"
 
 slack_ts_file="${1:?A Slack thread timestamp file is required as the first argument.}"


### PR DESCRIPTION
#### Vendored scripts after move at different relative path

When moving the workflow to folder phylogenetic
we need to adjust the path to the vendored script dir
which is used by Slack notify-on* scripts in the phylogenetic
workflow

If we ever centralize these scripts, we might want to allow
the vendor dir to be passed via an argument
this was quite a fixed assumption deep in the code, hard to
find before testing

See changes: https://github.com/nextstrain/monkeypox/pull/201/files#diff-b30e0f3bd03a03bd7a30bde82b5a2254893ea8369c841f79c3c9168b9136a18e

#### `pathogen-repo-build` args need to be adjusted to account for fact that files above the workflow root are needed

See changes: https://github.com/nextstrain/monkeypox/pull/201/files#diff-e41bb7e56e6e234a06e78585e851d80da70f1a0baea79f6f507bbe9814a23566

### Test
- [x] https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/179eb2a3-546f-4e33-90ae-4a13aa26412f
