### PR TITLE
Move s3_dst config to top level config

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -32,7 +32,7 @@ def _get_all_targets(wildcards):
             print(
                 f"Skipping file upload for {target!r} because there are duplicate remote file names."
             )
-        elif not params.get("dst"):
+        elif not params.get("s3_dst"):
             print(
                 f"Skipping file upload for {target!r} because the destintion was not defined."
             )

--- a/ingest/config/optional.yaml
+++ b/ingest/config/optional.yaml
@@ -1,10 +1,10 @@
 # Optional configs used by Nextstrain team
 # Params for uploads
+# AWS S3 Bucket with prefix
+s3_dst: 's3://nextstrain-data/files/workflows/monkeypox'
 upload:
   # Upload params for AWS S3
   s3:
-    # AWS S3 Bucket with prefix
-    dst: 's3://nextstrain-data/files/workflows/monkeypox'
     # Files to upload to S3 that are in the `data` directory
     files_to_upload: [
       'genbank.ndjson',

--- a/ingest/workflow/snakemake_rules/upload.smk
+++ b/ingest/workflow/snakemake_rules/upload.smk
@@ -52,7 +52,7 @@ rule upload_to_s3:
         "data/upload/s3/{file_to_upload}-to-{remote_file_name}.done",
     params:
         quiet="" if send_notifications else "--quiet",
-        s3_dst=config["upload"].get("s3", {}).get("dst", ""),
+        s3_dst=config.get("s3_dst", ""),
         cloudfront_domain=config["upload"].get("s3", {}).get("cloudfront_domain", ""),
     shell:
         """


### PR DESCRIPTION
## Description of proposed changes

Nested configs for s3 URLs are challenging to override by the Snakemake `--config` option, as discussed in the following comment:

https://github.com/nextstrain/dengue/pull/13#discussion_r1361131210

This moves the url to the top level as a `s3_dst` config value, and propagate those changes to the relevant Snakefiles. 
It's important to note that I haven't conducted thorough testing, and there may be nuances in the implementation meant by the comment. Suggestions or clarification welcome. 

Additionally, I was unsure regarding whether the `s3_dst` config should be a required value or an optional default ([Snakemake styleguide: config values](https://docs.nextstrain.org/en/latest/reference/snakemake-style-guide.html#access-config-values-appropriately)). 

## Related issue(s)

* https://github.com/nextstrain/dengue/pull/13#discussion_r1361131210

## Checklist

- [ ] Checks pass

