### PR TITLE
phylogenetic: Update notify scripts to use shared/vendored

### DIFF
--- a/phylogenetic/bin/notify-on-deploy
+++ b/phylogenetic/bin/notify-on-deploy
@@ -5,11 +5,11 @@ set -euo pipefail
 : "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
 
 base="$(realpath "$(dirname "$0")/../..")"
-ingest_vendored="$base/ingest/vendored"
+shared_vendored="$base/shared/vendored/scripts"
 
 deployment_url="${1:?A deployment url is required as the first argument.}"
 slack_ts_file="${2:?A Slack thread timestamp file is required as the second argument.}"
 
 echo "Notifying Slack about deployed builds."
-"$ingest_vendored"/notify-slack "Deployed this build to $deployment_url" \
+"$shared_vendored"/notify-slack "Deployed this build to $deployment_url" \
     --thread-ts="$(cat "$slack_ts_file")"

--- a/phylogenetic/bin/notify-on-error
+++ b/phylogenetic/bin/notify-on-error
@@ -8,7 +8,7 @@ set -euo pipefail
 : "${GITHUB_RUN_ID:=}"
 
 base="$(realpath "$(dirname "$0")/../..")"
-ingest_vendored="$base/ingest/vendored"
+shared_vendored="$base/shared/vendored/scripts"
 
 slack_ts_file="${1:-}"
 
@@ -26,6 +26,6 @@ elif [[ -n "${GITHUB_RUN_ID}" ]]; then
   message+="See GitHub Action <https://github.com/nextstrain/mpox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}> for error details."
 fi
 
-"$ingest_vendored"/notify-slack "$message" \
+"$shared_vendored"/notify-slack "$message" \
   --thread-ts="$thread_ts" \
   --broadcast

--- a/phylogenetic/bin/notify-on-start
+++ b/phylogenetic/bin/notify-on-start
@@ -8,7 +8,7 @@ set -euo pipefail
 : "${GITHUB_RUN_ID:=}"
 
 base="$(realpath "$(dirname "$0")/../..")"
-ingest_vendored="$base/ingest/vendored"
+shared_vendored="$base/shared/vendored/scripts"
 
 build_name="${1:?A build name is required as the first argument.}"
 slack_ts_output="${2:?A Slack thread timestamp file is required as the second argument}"
@@ -29,7 +29,7 @@ if [[ -n "${AWS_BATCH_JOB_ID}" ]]; then
   message+=" Follow along in your local \`mpox\` repo with: "'```'"nextstrain build --aws-batch --no-download --attach ${AWS_BATCH_JOB_ID} . "'```'
 fi
 
-"$ingest_vendored"/notify-slack "$message" --output="$slack_response"
+"$shared_vendored"/notify-slack "$message" --output="$slack_response"
 
 echo "Saving Slack thread timestamp to '$slack_ts_output'."
 

--- a/phylogenetic/bin/notify-on-success
+++ b/phylogenetic/bin/notify-on-success
@@ -5,10 +5,10 @@ set -euo pipefail
 : "${SLACK_CHANNELS:?The SLACK_CHANNELS environment variable is required.}"
 
 base="$(realpath "$(dirname "$0")/../..")"
-ingest_vendored="$base/ingest/vendored"
+shared_vendored="$base/shared/vendored/scripts"
 
 slack_ts_file="${1:?A Slack thread timestamp file is required as the first argument.}"
 
 echo "Notifying Slack about successful build."
-"$ingest_vendored"/notify-slack "✅ This pipeline has successfully finished 🎉" \
+"$shared_vendored"/notify-slack "✅ This pipeline has successfully finished 🎉" \
   --thread-ts="$(cat "$slack_ts_file")"


### PR DESCRIPTION
## Description of proposed changes

I missed the phylo notify scripts used the ingest/vendored scripts in  https://github.com/nextstrain/mpox/pull/326.

Resolves https://github.com/nextstrain/mpox/issues/328

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
