### PR TITLE
phylogenetic: Fix WorkflowError from Snakemake >=9.12.0

### DIFF
--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -66,6 +66,7 @@ rule filter:
 # Only define `add_private_data` rule when the config params are provided
 # so that Snakemake >= 9.12.0 doesn't fail due to optional inputs
 if config.get("private_sequences") and config.get("private_metadata"):
+
     # At this point we merge in private data (iff requested)
     rule add_private_data:
         """


### PR DESCRIPTION
## Description of proposed changes

Only define the optional `add_private_data` rule when the optional config parameters are provided so that Snakemake does not fail on empty inputs. 

Resolves https://github.com/nextstrain/mpox/issues/340

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
