### PR TITLE
ingest/extract_open_data: Do not compress intermediate files

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -48,8 +48,8 @@ rule extract_open_data:
         metadata="results/metadata.tsv",
         sequences="results/sequences.fasta",
     output:
-        metadata="results/metadata_open.tsv.zst",
-        sequences="results/sequences_open.fasta.zst",
+        metadata="results/metadata_open.tsv",
+        sequences="results/sequences_open.fasta",
     shell:
         """
         augur filter --metadata {input.metadata} \

--- a/ingest/build-configs/nextstrain-automation/config.yaml
+++ b/ingest/build-configs/nextstrain-automation/config.yaml
@@ -22,8 +22,8 @@ upload:
       alignment_with_restricted.fasta.zst: results/alignment.fasta
       translations_with_restricted.zip: results/translations.zip
 
-      metadata.tsv.zst: results/metadata_open.tsv.zst
-      sequences.fasta.zst: results/sequences_open.fasta.zst
+      metadata.tsv.zst: results/metadata_open.tsv
+      sequences.fasta.zst: results/sequences_open.fasta
 
     cloudfront_domain: 'data.nextstrain.org'
 


### PR DESCRIPTION

## Description of proposed changes

Use uncompressed outputs so that the uploaded files are no longer double compressed.¹

Once `upload-to-s3` supports compressed local files, we can go back to using compressed intermediate files.

## Related issue(s)

Related to https://github.com/nextstrain/mpox/issues/343

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
