### PR TITLE
config: Note Pathoplexus data use terms

### DIFF
--- a/phylogenetic/defaults/clade-i/config.yaml
+++ b/phylogenetic/defaults/clade-i/config.yaml
@@ -1,5 +1,8 @@
 inputs:
   - name: pathoplexus
+    # NOTE: These files contain restricted sequences. If you are using these in
+    # your own analysis, please refer to the Pathoplexus Data Use Terms.
+    # <https://pathoplexus.org/about/terms-of-use/restricted-data>
     metadata: "https://data.nextstrain.org/files/workflows/mpox/metadata_with_restricted.tsv.zst"
     sequences: "https://data.nextstrain.org/files/workflows/mpox/sequences_with_restricted.fasta.zst"
 

--- a/phylogenetic/defaults/hmpxv1/config.yaml
+++ b/phylogenetic/defaults/hmpxv1/config.yaml
@@ -1,5 +1,8 @@
 inputs:
   - name: pathoplexus
+    # NOTE: These files contain restricted sequences. If you are using these in
+    # your own analysis, please refer to the Pathoplexus Data Use Terms.
+    # <https://pathoplexus.org/about/terms-of-use/restricted-data>
     metadata: "https://data.nextstrain.org/files/workflows/mpox/metadata_with_restricted.tsv.zst"
     sequences: "https://data.nextstrain.org/files/workflows/mpox/sequences_with_restricted.fasta.zst"
 

--- a/phylogenetic/defaults/hmpxv1_big/config.yaml
+++ b/phylogenetic/defaults/hmpxv1_big/config.yaml
@@ -1,5 +1,8 @@
 inputs:
   - name: pathoplexus
+    # NOTE: These files contain restricted sequences. If you are using these in
+    # your own analysis, please refer to the Pathoplexus Data Use Terms.
+    # <https://pathoplexus.org/about/terms-of-use/restricted-data>
     metadata: "https://data.nextstrain.org/files/workflows/mpox/metadata_with_restricted.tsv.zst"
     sequences: "https://data.nextstrain.org/files/workflows/mpox/sequences_with_restricted.fasta.zst"
 

--- a/phylogenetic/defaults/mpxv/config.yaml
+++ b/phylogenetic/defaults/mpxv/config.yaml
@@ -1,5 +1,8 @@
 inputs:
   - name: pathoplexus
+    # NOTE: These files contain restricted sequences. If you are using these in
+    # your own analysis, please refer to the Pathoplexus Data Use Terms.
+    # <https://pathoplexus.org/about/terms-of-use/restricted-data>
     metadata: "https://data.nextstrain.org/files/workflows/mpox/metadata_with_restricted.tsv.zst"
     sequences: "https://data.nextstrain.org/files/workflows/mpox/sequences_with_restricted.fasta.zst"
 


### PR DESCRIPTION
Without a note, users would have to check the Data Use Terms columns for compliance, which might not be an obvious step.