### PR TITLE
fix(nextclade): align dataset metadata with schema

### DIFF
--- a/nextclade/resources/all-clades/pathogen.json
+++ b/nextclade/resources/all-clades/pathogen.json
@@ -16,9 +16,6 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": false,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -28,7 +25,6 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "official": true,
   "qc": {
     "frameShifts": {
       "enabled": true,

--- a/nextclade/resources/clade-i/pathogen.json
+++ b/nextclade/resources/clade-i/pathogen.json
@@ -16,9 +16,6 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": false,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -28,7 +25,6 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "official": true,
   "qc": {
     "frameShifts": {
       "enabled": true,

--- a/nextclade/resources/clade-iib/pathogen.json
+++ b/nextclade/resources/clade-iib/pathogen.json
@@ -16,9 +16,6 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": false,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -28,7 +25,6 @@
     "reference": "reference.fasta",
     "treeJson": "tree.json"
   },
-  "official": true,
   "qc": {
     "frameShifts": {
       "enabled": true,

--- a/nextclade/resources/lineage-b.1/pathogen.json
+++ b/nextclade/resources/lineage-b.1/pathogen.json
@@ -16,9 +16,6 @@
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": false,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",
@@ -99,7 +96,6 @@
       "95034G": ["rev"]
     }
   },
-  "official": true,
   "qc": {
     "frameShifts": {
       "enabled": true,


### PR DESCRIPTION
Remove obsolete top-level metadata fields from all 4 Nextclade dataset configs.

These fields are not defined in the pathogen.json schema and are silently ignored by Nextclade. The `enabled` and `official` fields do not exist in the schema at all. The `deprecated` and `experimental` flags belong under `attributes` but are both `false` (the default), so they are removed rather than moved.

| Field | Action | Datasets |
|---|---|---|
| `deprecated: false` | Remove (default is false) | all-clades, clade-i, clade-iib, lineage-b.1 |
| `experimental: false` | Remove (default is false) | all-clades, clade-i, clade-iib, lineage-b.1 |
| `enabled: true` | Remove (not in schema) | all-clades, clade-i, clade-iib, lineage-b.1 |
| `official: true` | Remove (not in schema) | all-clades, clade-i, clade-iib, lineage-b.1 |

- [x] Remove `deprecated`, `experimental`, `enabled`, `official` from 4 dataset configs

> :warning: The existing datasets in `nextclade_data` are already patched in nextstrain/nextclade_data#436, so no immediate resubmission is needed. But without this upstream fix, the obsolete fields will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) for the `PathogenJson` definition.

1. Related to: nextstrain/nextclade_data#436