### PR TITLE
Bump GH Action workflow resources

### DIFF
--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -50,12 +50,16 @@ jobs:
         SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: hmpxv1_big
+      # Aiming to use c7a.8xlarge instances since previous runs with c7a.4xlarge
+      # failed with OOM error. Note c7a.8xlarge is the largest instance allowed
+      # for the default nextstrain-job-queue. If this needs more memory,
+      # consider adding a separate job queue for larger instances.
       run: |
         nextstrain build \
           --detach \
           --no-download \
-          --cpus 16 \
-          --memory 28GiB \
+          --cpus 32 \
+          --memory 60GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -50,12 +50,14 @@ jobs:
         SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: hmpxv1
+      # Aiming for c7a.xlarge instances since previous run with c7a.large failed
+      # with OOM error.
       run: |
         nextstrain build \
           --detach \
           --no-download \
-          --cpus 2 \
-          --memory 4GiB \
+          --cpus 4 \
+          --memory 7GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -50,12 +50,14 @@ jobs:
         SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: mpxv
+      # Aiming for c7a.2xlarge instances since previous run with c7a.xlarge
+      # failed with OOM error.
       run: |
         nextstrain build \
           --detach \
           --no-download \
-          --cpus 2 \
-          --memory 4GiB \
+          --cpus 8 \
+          --memory 14GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \


### PR DESCRIPTION
## Description of proposed changes

Previous runs failed with OOM errors, so bumping resources to aim for the next instance up. If rebuild-hmpvx1-big still fails, then we need to consider creating a larger instance job queue.

## Related issue(s)

Follow up to https://github.com/nextstrain/mpox/commit/23a1d99756e9ec97a074e77ad123eb066e4918f2 and discussion on [Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1779670494277149)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
