### PR TITLE
Add run_config to results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the outputs of the workflows.
 Changes for this project _do not_ currently follow the [Semantic Versioning rules](https://semver.org/spec/v2.0.0.html).
 Instead, changes appear below grouped by the date they were added to the workflow.
 
+## 2026
+* 20 July 2026: phylogenetic - add run_config output
+  * Added write_config function to config.smk to generate the results/run_config.yaml output.
 
 ## 2025
 

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -49,7 +49,7 @@ rule all:
         cp {input.root_sequence:q} {output.root_sequence_json:q}
         """
 
-
+include: "../shared/vendored/snakemake/config.smk" # Utility functions shared across all workflows.
 include: "../shared/vendored/snakemake/remote_files.smk"
 include: "rules/config.smk"
 include: "rules/merge_inputs.smk"

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -49,7 +49,8 @@ rule all:
         cp {input.root_sequence:q} {output.root_sequence_json:q}
         """
 
-include: "../shared/vendored/snakemake/config.smk" # Utility functions shared across all workflows.
+
+include: "../shared/vendored/snakemake/config.smk"  # Utility functions shared across all workflows.
 include: "../shared/vendored/snakemake/remote_files.smk"
 include: "rules/config.smk"
 include: "rules/merge_inputs.smk"

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -108,3 +108,5 @@ if config.get("treefix_root", "").startswith(ROOT_FLAG):
         file=sys.stderr,
     )
     config["treefix_root"] = config["treefix_root"][len(ROOT_FLAG) :]
+
+write_config("results/run_config.yaml")


### PR DESCRIPTION
## Description of proposed changes

Adds the existing write_config function to config.smk to generate the run_config.yaml output in results (similar to mumps build: https://github.com/nextstrain/mumps/blob/main/phylogenetic/rules/config.smk).
Requesting this addition to make it easier to check how parameters are parsed from custom builds. 

## Checklist

Tested primary build and WA state build. I think the run_config looks as expected for both.

- [ ] Checks pass
- [x] Update changelog
